### PR TITLE
Constraining Sugar constructor using existential types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
    "git.ignoreLimitWarning": true,
    "javascript.suggestionActions.enabled": false,
    "editor.codeLens": false,
-   "editor.fontFamily": "'Fixedsys Excelsior'",
+   "editor.fontFamily": "Fira Code",
    "editor.fontLigatures": true,
    "editor.guides.indentation": false,
    "editor.lineNumbers": "on",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,10 @@
    "git.ignoreLimitWarning": true,
    "javascript.suggestionActions.enabled": false,
    "editor.codeLens": false,
-   "editor.fontFamily": "Fira Code",
+   "editor.fontFamily": "'Fixedsys Excelsior'",
    "editor.fontLigatures": true,
    "editor.guides.indentation": false,
-   "editor.lineNumbers": "off",
+   "editor.lineNumbers": "on",
    "editor.occurrencesHighlight": false,
    "editor.renderLineHighlight": "none",
    "editor.selectionHighlight": false

--- a/src/DesugarFwd2.purs
+++ b/src/DesugarFwd2.purs
@@ -22,7 +22,6 @@ import Lattice2 (class JoinSemilattice, maybeJoin)
 import SExpr2 (Branch, Clause, ListRest(..), ListRestPattern(..), Module(..), Pattern(..), Qualifier(..), RecDefs, SExpr(..), VarDef(..), VarDefs)
 import Util (type (+), type (×), MayFail, absurd, error, successful, (×))
 
-
 desugarFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
 desugarFwd = exprFwd
 
@@ -40,7 +39,7 @@ elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
 
 -- Surface language supports "blocks" of variable declarations; core does not.
 moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
-moduleFwd (Module ds) = 
+moduleFwd (Module ds) =
    E.Module <$> traverse varDefOrRecDefsFwd (join (desugarDefs <$> ds))
    where
    varDefOrRecDefsFwd :: VarDef a + RecDefs a -> MayFail (E.VarDef a + E.RecDefs a)
@@ -74,10 +73,10 @@ recDefFwd xcs = (fst (head xcs) ↦ _) <$> branchesFwd_curried (snd <$> xcs)
 exprFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
 exprFwd (BinaryApp s1 op s2) = pure (E.App (E.App (E.Op op) s1) s2)
 exprFwd (MatchAs s bs) = E.App <$> (E.Lambda <$> branchesFwd_uncurried bs) <*> pure s
-exprFwd (IfElse s1 s2 s3) = 
+exprFwd (IfElse s1 s2 s3) =
    E.App (E.Lambda (elimBool (ContExpr s2) (ContExpr s3))) <$> pure s1
 exprFwd (ListEmpty α) = pure (enil α)
-exprFwd (ListNonEmpty α s l) = pure (econs α s ( E.Sugar $ thunkSugar l))
+exprFwd (ListNonEmpty α s l) = pure (econs α s (E.Sugar $ thunkSugar l))
 exprFwd (ListEnum s1 s2) = E.App <$> ((E.App (E.Var "enumFromTo")) <$> pure s1) <*> pure s2
 -- | List-comp-done
 exprFwd (ListComp _ s_body (NonEmptyList (Guard (E.Constr α2 c Nil) :| Nil))) | c == cTrue =

--- a/src/DesugarFwd2.purs
+++ b/src/DesugarFwd2.purs
@@ -40,7 +40,7 @@ elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
 
 -- Surface language supports "blocks" of variable declarations; core does not.
 moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
-moduleFwd (Module ds) = 
+moduleFwd (Module ds) =
    E.Module <$> traverse varDefOrRecDefsFwd (join (desugarDefs <$> ds))
    where
    varDefOrRecDefsFwd :: VarDef a + RecDefs a -> MayFail (E.VarDef a + E.RecDefs a)
@@ -74,7 +74,7 @@ recDefFwd xcs = (fst (head xcs) ↦ _) <$> branchesFwd_curried (snd <$> xcs)
 exprFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
 exprFwd (BinaryApp s1 op s2) = pure (E.App (E.App (E.Op op) s1) s2)
 exprFwd (MatchAs s bs) = E.App <$> (E.Lambda <$> branchesFwd_uncurried bs) <*> pure s
-exprFwd (IfElse s1 s2 s3) = 
+exprFwd (IfElse s1 s2 s3) =
    E.App (E.Lambda (elimBool (ContExpr s2) (ContExpr s3))) <$> pure s1
 exprFwd (ListEmpty α) = pure (enil α)
 exprFwd (ListNonEmpty α s l) = pure (econs α s ( E.Sugar $ thunkSugar l))

--- a/src/DesugarFwd2.purs
+++ b/src/DesugarFwd2.purs
@@ -1,0 +1,167 @@
+module DesugarFwd2 where
+
+import Prelude hiding (absurd, otherwise)
+
+import Bindings (Bind, (↦), keys, varAnon)
+import Data.Either (Either(..))
+import Data.Foldable (foldM)
+import Data.Function (applyN, on)
+import Data.List (List(..), (:), (\\), length, sortBy)
+import Data.List (singleton) as L
+import Data.List.NonEmpty (NonEmptyList(..), groupBy, head, toList)
+import Data.NonEmpty ((:|))
+import Data.Set (toUnfoldable) as S
+import Data.Traversable (traverse)
+import Data.Tuple (fst, snd, uncurry)
+import DataType (Ctr, arity, checkArity, ctrs, cCons, cFalse, cNil, cTrue, dataTypeFor)
+import Dict (Dict, asSingletonMap)
+import Dict (fromFoldable, singleton) as D
+import Expr2 (Expr(..), Module(..), RecDefs, VarDef(..)) as E
+import Expr2 (Cont(..), Elim(..), asElim, mkSugar)
+import Lattice2 (class JoinSemilattice, maybeJoin)
+import SExpr2 (Branch, Clause, ListRest(..), ListRestPattern(..), Module(..), Pattern(..), Qualifier(..), RecDefs, SExpr(..), VarDef(..), VarDefs)
+import Util (type (+), type (×), MayFail, absurd, error, successful, (×))
+
+
+desugarFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
+desugarFwd = exprFwd
+
+desugarModuleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
+desugarModuleFwd = moduleFwd
+
+enil :: forall a. a -> E.Expr a
+enil α = E.Constr α cNil Nil
+
+econs :: forall a. a -> E.Expr a -> E.Expr a -> E.Expr a
+econs α e e' = E.Constr α cCons (e : e' : Nil)
+
+elimBool :: forall a. Cont a -> Cont a -> Elim a
+elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
+
+-- Surface language supports "blocks" of variable declarations; core does not.
+moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
+moduleFwd (Module ds) = E.Module <$> traverse varDefOrRecDefsFwd (join (desugarDefs <$> ds))
+   where
+   varDefOrRecDefsFwd :: VarDef a + RecDefs a -> MayFail (E.VarDef a + E.RecDefs a)
+   varDefOrRecDefsFwd (Left d) = Left <$> varDefFwd d
+   varDefOrRecDefsFwd (Right xcs) = Right <$> recDefsFwd xcs
+
+   desugarDefs :: VarDefs a + RecDefs a -> List (VarDef a + RecDefs a)
+   desugarDefs (Left ds') = Left <$> toList ds'
+   desugarDefs (Right δ) = pure (Right δ)
+
+varDefFwd :: forall a. JoinSemilattice a => VarDef a -> MayFail (E.VarDef a)
+varDefFwd (VarDef π s) = E.VarDef <$> patternFwd π (ContNone :: Cont a) <*> pure s
+
+varDefsFwd :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> MayFail (E.Expr a)
+varDefsFwd (NonEmptyList (d :| Nil) × s) =
+   E.Let <$> varDefFwd d <*> pure s
+varDefsFwd (NonEmptyList (d :| d' : ds) × s) =
+   E.Let <$> varDefFwd d <*> varDefsFwd (NonEmptyList (d' :| ds) × s)
+
+-- In the formalism, "group by name" is part of the syntax.
+-- cs desugar_fwd σ
+recDefsFwd :: forall a. JoinSemilattice a => RecDefs a -> MayFail (E.RecDefs a)
+recDefsFwd xcs = D.fromFoldable <$> traverse recDefFwd xcss
+   where
+   xcss = groupBy (eq `on` fst) xcs :: NonEmptyList (NonEmptyList (Clause a))
+
+recDefFwd :: forall a. JoinSemilattice a => NonEmptyList (Clause a) -> MayFail (Bind (Elim a))
+recDefFwd xcs = (fst (head xcs) ↦ _) <$> branchesFwd_curried (snd <$> xcs)
+
+-- s desugar_fwd e
+exprFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
+exprFwd (BinaryApp s1 op s2) = pure (E.App (E.App (E.Op op) s1) s2)
+exprFwd (MatchAs s bs) = E.App <$> (E.Lambda <$> branchesFwd_uncurried bs) <*> pure s
+exprFwd (IfElse s1 s2 s3) = 
+   E.App (E.Lambda (elimBool (ContExpr s2) (ContExpr s3))) <$> pure s1
+exprFwd (ListEmpty α) = pure (enil α)
+exprFwd (ListNonEmpty α s l) = pure (econs α s (mkSugar l))
+exprFwd (ListEnum s1 s2) = E.App <$> ((E.App (E.Var "enumFromTo")) <$> pure s1) <*> pure s2
+-- | List-comp-done
+exprFwd (ListComp _ s_body (NonEmptyList (Guard (E.Constr α2 c Nil) :| Nil))) | c == cTrue =
+   pure (econs α2 s_body (enil α2))
+-- | List-comp-last
+exprFwd (ListComp α s_body (NonEmptyList (q :| Nil))) =
+   exprFwd (ListComp α s_body (NonEmptyList (q :| Guard (E.Constr α cTrue Nil) : Nil)))
+-- | List-comp-guard
+exprFwd (ListComp α s_body (NonEmptyList (Guard s :| q : qs))) = do
+   e <- exprFwd (ListComp α s_body (NonEmptyList (q :| qs)))
+   E.App (E.Lambda (elimBool (ContExpr e) (ContExpr (enil α)))) <$> pure s
+-- | List-comp-decl
+exprFwd (ListComp α s_body (NonEmptyList (Declaration (VarDef π s) :| q : qs))) = do
+   e <- exprFwd (ListComp α s_body (NonEmptyList (q :| qs)))
+   σ <- patternFwd π (ContExpr e :: Cont a)
+   E.App (E.Lambda σ) <$> pure s
+-- | List-comp-gen
+exprFwd (ListComp α s_body (NonEmptyList (Generator p s :| q : qs))) = do
+   e <- exprFwd (ListComp α s_body (NonEmptyList (q :| qs)))
+   σ <- patternFwd p (ContExpr e)
+   E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totaliseFwd (ContElim σ) α)))) <$> pure s
+exprFwd (Let ds s) = varDefsFwd (ds × s)
+exprFwd (LetRec xcs s) = E.LetRec <$> recDefsFwd xcs <*> pure s
+
+-- l desugar_fwd e
+listRestFwd :: forall a. JoinSemilattice a => ListRest a -> MayFail (E.Expr a)
+listRestFwd (End α) = pure (enil α)
+listRestFwd (Next α s l) = pure (econs α s (mkSugar l))
+
+-- ps, e desugar_fwd σ
+patternsFwd :: forall a. JoinSemilattice a => NonEmptyList Pattern × E.Expr a -> MayFail (Elim a)
+patternsFwd (NonEmptyList (p :| Nil) × e) = branchFwd_uncurried p e
+patternsFwd (NonEmptyList (p :| p' : ps) × e) =
+   patternFwd p =<< ContExpr <$> E.Lambda <$> patternsFwd (NonEmptyList (p' :| ps) × e)
+
+patternFwd :: forall a. Pattern -> Cont a -> MayFail (Elim a)
+patternFwd (PVar x) κ = pure (ElimVar x κ)
+patternFwd (PConstr c ps) κ =
+   checkArity c (length ps) *> (ElimConstr <$> D.singleton c <$> argPatternFwd (Left <$> ps) κ)
+patternFwd (PRecord xps) κ = ElimRecord (keys xps) <$> recordPatternFwd (sortBy (flip compare `on` fst) xps) κ
+patternFwd PListEmpty κ = pure (ElimConstr (D.singleton cNil κ))
+patternFwd (PListNonEmpty p o) κ = ElimConstr <$> D.singleton cCons <$> argPatternFwd (Left p : Right o : Nil) κ
+
+-- o, κ desugar_fwd σ
+listRestPatternFwd :: forall a. ListRestPattern -> Cont a -> MayFail (Elim a)
+listRestPatternFwd PEnd κ = pure (ElimConstr (D.singleton cNil κ))
+listRestPatternFwd (PNext p o) κ = ElimConstr <$> D.singleton cCons <$> argPatternFwd (Left p : Right o : Nil) κ
+
+argPatternFwd :: forall a. List (Pattern + ListRestPattern) -> Cont a -> MayFail (Cont a)
+argPatternFwd Nil κ = pure κ
+argPatternFwd (Left p : πs) κ = ContElim <$> (argPatternFwd πs κ >>= patternFwd p)
+argPatternFwd (Right o : πs) κ = ContElim <$> (argPatternFwd πs κ >>= listRestPatternFwd o)
+
+recordPatternFwd :: forall a. List (Bind Pattern) -> Cont a -> MayFail (Cont a)
+recordPatternFwd Nil κ = pure κ
+recordPatternFwd (_ ↦ p : xps) κ = patternFwd p κ >>= ContElim >>> recordPatternFwd xps
+
+branchFwd_uncurried :: forall a. JoinSemilattice a => Pattern -> E.Expr a -> MayFail (Elim a)
+branchFwd_uncurried p s = let cont = ContExpr s in patternFwd p cont
+
+branchesFwd_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> MayFail (Elim a)
+branchesFwd_curried bs = do
+   NonEmptyList (σ :| σs) <- traverse patternsFwd bs
+   foldM maybeJoin σ σs
+
+branchesFwd_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × E.Expr a) -> MayFail (Elim a)
+branchesFwd_uncurried bs = do
+   NonEmptyList (σ :| σs) <- traverse (uncurry branchFwd_uncurried) bs
+   foldM maybeJoin σ σs
+
+totaliseFwd :: forall a. Cont a -> a -> Cont a
+totaliseFwd ContNone _ = error absurd
+totaliseFwd (ContExpr e) _ = ContExpr e
+totaliseFwd (ContElim (ElimConstr m)) α = ContElim (ElimConstr (totaliseConstrFwd (c × totaliseFwd κ α) α))
+   where
+   c × κ = asSingletonMap m
+totaliseFwd (ContElim (ElimRecord xs κ)) α = ContElim (ElimRecord xs (totaliseFwd κ α))
+totaliseFwd (ContElim (ElimVar x κ)) α = ContElim (ElimVar x (totaliseFwd κ α))
+
+-- Extend singleton branch to set of branches where any missing constructors have been mapped to the empty list,
+-- using anonymous variables in any generated patterns.
+totaliseConstrFwd :: forall a. Ctr × Cont a -> a -> Dict (Cont a)
+totaliseConstrFwd (c × κ) α =
+   let
+      defaultBranch c' = c' × applyN (ContElim <<< ElimVar varAnon) (successful (arity c')) (ContExpr (enil α))
+      cκs = defaultBranch <$> ((ctrs (successful (dataTypeFor c)) # S.toUnfoldable) \\ L.singleton c)
+   in
+      D.fromFoldable ((c × κ) : cκs)

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -17,7 +17,7 @@ import Data.Tuple (fst, snd)
 import DataType (Ctr, arity, consistentWith, dataTypeFor, showCtr)
 import Dict (disjointUnion, get, empty, lookup, keys)
 import Dict (fromFoldable, singleton, unzip) as D
-import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv)
+import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv, runSugar)
 import Lattice2 ((∧), erase, top)
 import Pretty2 (prettyP)
 import Primitive2 (intPair, string)
@@ -60,7 +60,7 @@ matchMany (_ : vs) (ContExpr _) = report $
    show (length vs + 1) <> " extra argument(s) to constructor/record; did you forget parentheses in lambda pattern?"
 matchMany _ _ = error absurd
 
-closeDefs :: forall a. Env a -> RecDefs a -> a -> Env a
+closeDefs :: forall a. Ann a => Env a -> RecDefs a -> a -> Env a
 closeDefs γ ρ α = ρ <#> \σ ->
    let ρ' = ρ `for` σ in V.Fun $ V.Closure α (γ `restrict` (fv ρ' `union` fv σ)) ρ' σ
 

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -158,7 +158,7 @@ eval γ (LetRec ρ e) α = do
    let γ' = closeDefs γ ρ α
    t × v <- eval (γ <+> γ') e α
    pure $ T.LetRec (erase <$> ρ) t × v
-eval _ (Sugar _) _ = error "todo"
+eval env (Sugar s) ann = eval env (desug (runSugar s)) ann
 
 eval_module :: forall a. Ann a => Env a -> Module a -> a -> MayFail (Env a)
 eval_module γ = go empty

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -17,7 +17,7 @@ import Data.Tuple (fst, snd)
 import DataType (Ctr, arity, consistentWith, dataTypeFor, showCtr)
 import Dict (disjointUnion, get, empty, lookup, keys)
 import Dict (fromFoldable, singleton, unzip) as D
-import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv)
+import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv, runSugar)
 import Lattice2 ((∧), erase, top)
 import Pretty2 (prettyP)
 import Primitive2 (intPair, string)

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -17,7 +17,7 @@ import Data.Tuple (fst, snd)
 import DataType (Ctr, arity, consistentWith, dataTypeFor, showCtr)
 import Dict (disjointUnion, get, empty, lookup, keys)
 import Dict (fromFoldable, singleton, unzip) as D
-import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv, runSugar)
+import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv, runSugarF)
 import Lattice2 ((∧), erase, top)
 import Pretty2 (prettyP)
 import Primitive2 (intPair, string)
@@ -158,7 +158,9 @@ eval γ (LetRec ρ e) α = do
    let γ' = closeDefs γ ρ α
    t × v <- eval (γ <+> γ') e α
    pure $ T.LetRec (erase <$> ρ) t × v
-eval env (Sugar s) ann = eval env (runSugar s) ann
+eval env (Sugar s) ann = do
+   desugged <- runSugarF s
+   eval env desugged ann
 
 eval_module :: forall a. Ann a => Env a -> Module a -> a -> MayFail (Env a)
 eval_module γ = go empty

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -158,7 +158,7 @@ eval γ (LetRec ρ e) α = do
    let γ' = closeDefs γ ρ α
    t × v <- eval (γ <+> γ') e α
    pure $ T.LetRec (erase <$> ρ) t × v
-eval env (Sugar s) ann = eval env (desug (runSugar s)) ann
+eval env (Sugar s) ann = eval env (runSugar s) ann
 
 eval_module :: forall a. Ann a => Env a -> Module a -> a -> MayFail (Env a)
 eval_module γ = go empty

--- a/src/Eval2.purs
+++ b/src/Eval2.purs
@@ -1,0 +1,173 @@
+module Eval2 where
+
+import Prelude hiding (absurd, apply, top)
+
+import Bindings (varAnon)
+import Data.Array (fromFoldable) as A
+import Data.Bifunctor (bimap)
+import Data.Either (Either(..), note)
+import Data.Exists (mkExists, runExists)
+import Data.List (List(..), (:), length, range, singleton, unzip, zip)
+import Data.Maybe (Maybe(..))
+import Data.Profunctor.Strong (first)
+import Data.Set (fromFoldable, toUnfoldable, singleton) as S
+import Data.Set (union, subset)
+import Data.Traversable (sequence, traverse)
+import Data.Tuple (fst, snd)
+import DataType (Ctr, arity, consistentWith, dataTypeFor, showCtr)
+import Dict (disjointUnion, get, empty, lookup, keys)
+import Dict (fromFoldable, singleton, unzip) as D
+import Expr2 (Cont(..), Elim(..), Expr(..), Module(..), RecDefs, VarDef(..), asExpr, fv)
+import Lattice2 ((∧), erase, top)
+import Pretty2 (prettyP)
+import Primitive2 (intPair, string)
+import Trace2 (AppTrace(..), Trace(..), VarDef(..)) as T
+import Trace2 (AppTrace, ForeignTrace, ForeignTrace'(..), Match(..), Trace)
+import Util (type (×), MayFail, absurd, both, check, error, report, successful, with, (×))
+import Util.Pair (unzip) as P
+import Val2 (Fun(..), Val(..)) as V
+import Val2 (class Ann, Env, ForeignOp'(..), (<+>), Val, for, lookup', restrict)
+
+patternMismatch :: String -> String -> String
+patternMismatch s s' = "Pattern mismatch: found " <> s <> ", expected " <> s'
+
+match :: forall a. Ann a => Val a -> Elim a -> MayFail (Env a × Cont a × a × Match)
+match v (ElimVar x κ)
+   | x == varAnon = pure (empty × κ × top × MatchVarAnon (erase v))
+   | otherwise = pure (D.singleton x v × κ × top × MatchVar x (erase v))
+match (V.Constr α c vs) (ElimConstr m) = do
+   with "Pattern mismatch" $ S.singleton c `consistentWith` keys m
+   κ <- note ("Incomplete patterns: no branch for " <> showCtr c) (lookup c m)
+   γ × κ' × α' × ws <- matchMany vs κ
+   pure (γ × κ' × (α ∧ α') × MatchConstr c ws)
+match v (ElimConstr m) = do
+   d <- dataTypeFor $ keys m
+   report $ patternMismatch (prettyP v) (show d)
+match (V.Record α xvs) (ElimRecord xs κ) = do
+   check (subset xs (S.fromFoldable $ keys xvs)) $ patternMismatch (show (keys xvs)) (show xs)
+   let xs' = xs # S.toUnfoldable
+   γ × κ' × α' × ws <- matchMany (xs' <#> flip get xvs) κ
+   pure (γ × κ' × (α ∧ α') × MatchRecord (D.fromFoldable (zip xs' ws)))
+match v (ElimRecord xs _) = report (patternMismatch (prettyP v) (show xs))
+
+matchMany :: forall a. Ann a => List (Val a) -> Cont a -> MayFail (Env a × Cont a × a × List Match)
+matchMany Nil κ = pure (empty × κ × top × Nil)
+matchMany (v : vs) (ContElim σ) = do
+   γ × κ' × α × w <- match v σ
+   γ' × κ'' × β × ws <- matchMany vs κ'
+   pure $ γ `disjointUnion` γ' × κ'' × (α ∧ β) × (w : ws)
+matchMany (_ : vs) (ContExpr _) = report $
+   show (length vs + 1) <> " extra argument(s) to constructor/record; did you forget parentheses in lambda pattern?"
+matchMany _ _ = error absurd
+
+closeDefs :: forall a. Env a -> RecDefs a -> a -> Env a
+closeDefs γ ρ α = ρ <#> \σ ->
+   let ρ' = ρ `for` σ in V.Fun $ V.Closure α (γ `restrict` (fv ρ' `union` fv σ)) ρ' σ
+
+checkArity :: Ctr -> Int -> MayFail Unit
+checkArity c n = do
+   n' <- arity c
+   check (n' >= n) (showCtr c <> " got " <> show n <> " argument(s), expects at most " <> show n')
+
+apply :: forall a. Ann a => Val a × Val a -> MayFail (AppTrace × Val a)
+apply (V.Fun (V.Closure β γ1 ρ σ) × v) = do
+   let γ2 = closeDefs γ1 ρ β
+   γ3 × e'' × β' × w <- match v σ
+   t'' × v'' <- eval (γ1 <+> γ2 <+> γ3) (asExpr e'') (β ∧ β')
+   pure $ T.AppClosure (S.fromFoldable (keys ρ)) w t'' × v''
+apply (V.Fun (V.Foreign φ vs) × v) = do
+   let vs' = vs <> singleton v
+   let
+      apply' :: forall t. ForeignOp' t -> MayFail (ForeignTrace × Val _)
+      apply' (ForeignOp' φ') = do
+         t × v'' <- do
+            if φ'.arity > length vs' then pure $ Nothing × V.Fun (V.Foreign φ vs')
+            else first Just <$> φ'.op vs'
+         pure $ mkExists (ForeignTrace' (ForeignOp' φ') t) × v''
+   t × v'' <- runExists apply' φ
+   pure $ T.AppForeign (length vs + 1) t × v''
+apply (V.Fun (V.PartialConstr α c vs) × v) = do
+   let n = successful (arity c)
+   check (length vs < n) ("Too many arguments to " <> showCtr c)
+   let
+      v' =
+         if length vs < n - 1 then V.Fun $ V.PartialConstr α c (vs <> singleton v)
+         else V.Constr α c (vs <> singleton v)
+   pure $ T.AppConstr c × v'
+apply (_ × v) = report $ "Found " <> prettyP v <> ", expected function"
+
+apply2 :: forall a. Ann a => Val a × Val a × Val a -> MayFail ((AppTrace × AppTrace) × Val a)
+apply2 (u1 × v1 × v2) = do
+   t1 × u2 <- apply (u1 × v1)
+   t2 × v <- apply (u2 × v2)
+   pure $ (t1 × t2) × v
+
+eval :: forall a. Ann a => Env a -> Expr a -> a -> MayFail (Trace × Val a)
+eval γ (Var x) _ = (T.Var x × _) <$> lookup' x γ
+eval γ (Op op) _ = (T.Op op × _) <$> lookup' op γ
+eval _ (Int α n) α' = pure (T.Const × V.Int (α ∧ α') n)
+eval _ (Float α n) α' = pure (T.Const × V.Float (α ∧ α') n)
+eval _ (Str α str) α' = pure (T.Const × V.Str (α ∧ α') str)
+eval γ (Record α xes) α' = do
+   xts × xvs <- traverse (flip (eval γ) α') xes <#> D.unzip
+   pure $ T.Record xts × V.Record (α ∧ α') xvs
+eval γ (Dictionary α ees) α' = do
+   (ts × vs) × (ts' × us) <- traverse (traverse (flip (eval γ) α')) ees <#> (P.unzip >>> (unzip # both))
+   let
+      ss × αs = (vs <#> \u -> string.match u) # unzip
+      d = D.fromFoldable $ zip ss (zip αs us)
+   pure $ T.Dictionary (zip ss (zip ts ts')) (d <#> snd >>> erase) × V.Dictionary (α ∧ α') d
+eval γ (Constr α c es) α' = do
+   checkArity c (length es)
+   ts × vs <- traverse (flip (eval γ) α') es <#> unzip
+   pure (T.Constr c ts × V.Constr (α ∧ α') c vs)
+eval γ (Matrix α e (x × y) e') α' = do
+   t × v <- eval γ e' α'
+   let (i' × β) × (j' × β') = fst (intPair.match v)
+   check (i' × j' >= 1 × 1) ("array must be at least (" <> show (1 × 1) <> "); got (" <> show (i' × j') <> ")")
+   tss × vss <- unzipToArray <$> ((<$>) unzipToArray) <$>
+      ( sequence $ do
+           i <- range 1 i'
+           singleton $ sequence $ do
+              j <- range 1 j'
+              let γ' = D.singleton x (V.Int β i) `disjointUnion` (D.singleton y (V.Int β' j))
+              singleton (eval (γ <+> γ') e α')
+      )
+   pure $ T.Matrix tss (x × y) (i' × j') t × V.Matrix (α ∧ α') (vss × (i' × β) × (j' × β'))
+   where
+   unzipToArray :: forall b c. List (b × c) -> Array b × Array c
+   unzipToArray = unzip >>> bimap A.fromFoldable A.fromFoldable
+eval γ (Lambda σ) α =
+   pure $ T.Const × V.Fun (V.Closure α (γ `restrict` fv σ) empty σ)
+eval γ (Project e x) α = do
+   t × v <- eval γ e α
+   case v of
+      V.Record _ xvs -> (T.Project t x × _) <$> lookup' x xvs
+      _ -> report $ "Found " <> prettyP v <> ", expected record"
+eval γ (App e e') α = do
+   t × v <- eval γ e α
+   t' × v' <- eval γ e' α
+   t'' × v'' <- apply (v × v')
+   pure $ T.App t t' t'' × v''
+eval γ (Let (VarDef σ e) e') α = do
+   t × v <- eval γ e α
+   γ' × _ × α' × w <- match v σ -- terminal meta-type of eliminator is meta-unit
+   t' × v' <- eval (γ <+> γ') e' α' -- (α ∧ α') for consistency with functions? (similarly for module defs)
+   pure $ T.Let (T.VarDef w t) t' × v'
+eval γ (LetRec ρ e) α = do
+   let γ' = closeDefs γ ρ α
+   t × v <- eval (γ <+> γ') e α
+   pure $ T.LetRec (erase <$> ρ) t × v
+eval _ (Sugar _) _ = error "todo"
+
+eval_module :: forall a. Ann a => Env a -> Module a -> a -> MayFail (Env a)
+eval_module γ = go empty
+   where
+   go :: Env a -> Module a -> a -> MayFail (Env a)
+   go γ' (Module Nil) _ = pure γ'
+   go y' (Module (Left (VarDef σ e) : ds)) α = do
+      _ × v <- eval (γ <+> y') e α
+      γ'' × _ × α' × _ <- match v σ
+      go (y' <+> γ'') (Module ds) α'
+   go γ' (Module (Right ρ : ds)) α =
+      go (γ' <+> closeDefs (γ <+> γ') ρ α) (Module ds) α

--- a/src/Expr.purs
+++ b/src/Expr.purs
@@ -59,7 +59,6 @@ data Module a = Module (List (VarDef a + RecDefs a))
 class FV a where
    fv :: a -> Set Var
 
-
 instance FV (Expr a) where
    fv (Var x) = singleton x
    fv (Op op) = singleton op

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -22,6 +22,8 @@ data Sugar' a
 
 class Desugarable s a where
     desug :: s a -> Expr a
+mkSugar :: forall s a. s a -> Expr a
+mkSugar x = Sugar ( mkSugar' {sexp: x} )
 
 mkSugar' :: forall a s. Sugar'' s a -> Sugar' a
 mkSugar' = unsafeCoerce

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -50,21 +50,22 @@ class Functor s <= Desugarable2 (s :: Type -> Type) where
 -- runSugar sug = runSugar' (\s -> desug s.sexp) sug
 
 instance Functor Sugar' where
--- k :: (forall r. (forall s. Desugarable2 s => s a -> r) -> r)
--- sug :: forall s. Desugarable2 s => s b -> r
+   -- k :: (forall r. (forall s. Desugarable2 s => s a -> r) -> r)
+   -- sug :: forall s. Desugarable2 s => s b -> r
    map :: forall a b. (a -> b) -> Sugar' a -> Sugar' b
-   map f (Sugar' k) = Sugar' ( \sug -> k (\sa -> sug (map f sa)) ) 
+   map f (Sugar' k) = Sugar' (\sug -> k (\sa -> sug (map f sa)))
 
 thunkSugarF :: forall a s. Desugarable2 s => s a -> Sugar' a
-thunkSugarF sug  = Sugar' (\ds -> ds sug)
+thunkSugarF sug = Sugar' (\ds -> ds sug)
 
 runSugarF :: forall a. JoinSemilattice a => Sugar' a -> MayFail (Expr a)
 runSugarF (Sugar' k) = k desug2
 
 instance Desugarable Sugar' where
    desug s = case (runSugar s) of
-               Left  _ -> error "todo"
-               Right _ -> error "todo"
+      Left _ -> error "todo"
+      Right _ -> error "todo"
+
 data Expr a
    = Var Var
    | Op Var

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -22,6 +22,8 @@ data Sugar' a
 
 class Desugarable s a where
     desug :: s a -> Expr a
+
+
 mkSugar :: forall s a. s a -> Expr a
 mkSugar x = Sugar ( mkSugar' {sexp: x} )
 
@@ -30,6 +32,9 @@ mkSugar' = unsafeCoerce
 
 runSugar' :: forall a r. (forall s. Functor s => Desugarable s a => Sugar'' s a -> r) -> Sugar' a -> r
 runSugar' = unsafeCoerce
+
+runSugar :: forall a s. Desugarable s a => Sugar' a -> Expr a
+runSugar sug = runSugar' (\s -> desug s.sexp) sug
 
 instance Functor Sugar' where 
     map :: forall a b. (a -> b) -> Sugar' a -> Sugar' b

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -34,7 +34,7 @@ mkSugar x = Sugar (mkSugar' { sexp: x })
 mkSugar' :: forall a s. Desugarable s => Sugar'' s a -> Sugar' a
 mkSugar' = unsafeCoerce
 
-runSugar' :: forall a r. (forall s. Functor s => Desugarable s a => Sugar'' s a -> r) -> Sugar' a -> r
+runSugar' :: forall a r. (forall s. Functor s => Desugarable s => Sugar'' s a -> r) -> Sugar' a -> r
 runSugar' = unsafeCoerce
 
 runSugar :: forall a. JoinSemilattice a => Sugar' a -> Expr a

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -4,14 +4,13 @@ import Prelude hiding (absurd, top)
 
 import Bindings (Var)
 import Control.Apply (lift2)
-import Data.Exists (Exists)
 import Data.List (List)
 import Data.Set (Set, difference, empty, singleton, union, unions)
 import Data.Set (fromFoldable) as S
 import Data.Tuple (snd)
 import DataType (Ctr, consistentWith)
 import Dict (Dict, keys, asSingletonMap)
-import Lattice (class BoundedJoinSemilattice, class Expandable, class JoinSemilattice, Raw, (∨), definedJoin, expand, maybeJoin, neg)
+import Lattice2 (class BoundedJoinSemilattice, class Expandable, class JoinSemilattice, Raw, (∨), definedJoin, expand, maybeJoin, neg)
 import Unsafe.Coerce (unsafeCoerce)
 import Util (type (+), type (×), both, error, report, (×), (≜), (≞))
 import Util.Pair (Pair, toTuple)
@@ -19,6 +18,7 @@ import Util.Pair (Pair, toTuple)
 
 type Sugar'' s a = { sexp :: s a }
 data Sugar' a
+
 
 class Desugarable s a where
     desug :: s a -> Expr a

--- a/src/Expr2.purs
+++ b/src/Expr2.purs
@@ -19,17 +19,14 @@ type Sugar'' (s :: Type -> Type) a = { sexp :: s a }
 
 data Sugar' (a :: Type)
 
-
 class Desugarable (s :: Type -> Type) where
-    desug :: forall a. JoinSemilattice a => s a -> Expr a
-
+   desug :: forall a. JoinSemilattice a => s a -> Expr a
 
 mkSugar2 :: forall s a. Desugarable s => s a -> Sugar' a
-mkSugar2 x = mkSugar' {sexp: x}
-
+mkSugar2 x = mkSugar' { sexp: x }
 
 mkSugar :: forall s a. Desugarable s => s a -> Expr a
-mkSugar x = Sugar ( mkSugar' {sexp: x} )
+mkSugar x = Sugar (mkSugar' { sexp: x })
 
 mkSugar' :: forall a s. Sugar'' s a -> Sugar' a
 mkSugar' = unsafeCoerce
@@ -41,13 +38,15 @@ runSugar :: forall a. JoinSemilattice a => Sugar' a -> Expr a
 runSugar sug = runSugar' (\s -> desug s.sexp) sug
 
 instance Functor Sugar' where
-    map :: forall a b. (a -> b) -> Sugar' a -> Sugar' b
-    map f x = runSugar' (\sugar'' ->
-      mkSugar' ({ sexp: map f (sugar''.sexp) })) x
-
+   map :: forall a b. (a -> b) -> Sugar' a -> Sugar' b
+   map f x = runSugar'
+      ( \sugar'' ->
+           mkSugar' ({ sexp: map f (sugar''.sexp) })
+      )
+      x
 
 instance Desugarable Sugar' where
-  desug _ = error "todo"
+   desug _ = error "todo"
 
 data Expr a
    = Var Var
@@ -111,8 +110,10 @@ instance JoinSemilattice a => FV (Expr a) where
    fv (Let def e) = fv def `union` (fv e `difference` bv def)
    fv (LetRec ρ e) = unions (fv <$> ρ) `union` fv e
    fv (Sugar s) =
-    let desugged = desug s :: Expr a in
-        fv desugged
+      let
+         desugged = desug s :: Expr a
+      in
+         fv desugged
 
 instance JoinSemilattice a => FV (Elim a) where
    fv (ElimVar x κ) = fv κ `difference` singleton x

--- a/src/Lattice2.purs
+++ b/src/Lattice2.purs
@@ -1,0 +1,149 @@
+module Lattice2 where
+
+import Prelude hiding (absurd, join)
+import Control.Apply (lift2)
+import Data.Array (zipWith) as A
+import Data.Foldable (length, foldM)
+import Data.List (List, zipWith)
+import Data.Maybe (Maybe(..))
+import Data.Profunctor.Strong ((***))
+import Data.Set (subset)
+import Data.Traversable (sequence)
+import Dict (Dict, difference, intersectionWith, lookup, insert, keys, toUnfoldable, union, unionWith, update)
+import Bindings (Var)
+import Util (Endo, MayFail, type (×), (×), assert, report, successfulWith)
+import Util.Pair (Pair(..))
+
+-- join here is actually more general "weak join" operation of the formalism, which operates on maps using unionWith.
+class JoinSemilattice a where
+   join :: a -> a -> a
+   -- soft failure for joining incompatible eliminators, used to desugar function clauses
+   maybeJoin :: a -> a -> MayFail a
+   -- TODO: extract new typeclass for neg
+   neg :: Endo a
+
+class MeetSemilattice a where
+   meet :: a -> a -> a
+
+class JoinSemilattice a <= BoundedJoinSemilattice a where
+   bot :: a
+
+class MeetSemilattice a <= BoundedMeetSemilattice a where
+   top :: a
+
+instance JoinSemilattice Boolean where
+   join = (||)
+   maybeJoin x y = pure (join x y)
+   neg = not
+
+instance MeetSemilattice Boolean where
+   meet = (&&)
+
+instance BoundedJoinSemilattice Boolean where
+   bot = false
+
+instance BoundedMeetSemilattice Boolean where
+   top = true
+
+instance JoinSemilattice Unit where
+   join _ = identity
+   maybeJoin x y = pure (join x y)
+   neg = identity
+
+instance MeetSemilattice Unit where
+   meet _ = identity
+
+instance BoundedJoinSemilattice Unit where
+   bot = unit
+
+instance BoundedMeetSemilattice Unit where
+   top = unit
+
+class (BoundedJoinSemilattice a, BoundedMeetSemilattice a) <= BoundedLattice a
+
+instance BoundedLattice Boolean
+instance BoundedLattice Unit
+
+definedJoin :: forall a. JoinSemilattice a => a -> a -> a
+definedJoin x = successfulWith "Join undefined" <<< maybeJoin x
+
+class BotOf t u | t -> u where
+   botOf :: t -> u
+
+class TopOf t u | t -> u where
+   topOf :: t -> u
+
+instance (Functor t, BoundedJoinSemilattice a) => BotOf (Unit × Raw t) (a × t a) where
+   botOf = const bot *** botOf
+else instance (Functor t, BoundedJoinSemilattice a, BoundedJoinSemilattice a') => BotOf (t a) (t a') where
+   botOf = (<$>) (const bot)
+
+instance (Functor t, BoundedJoinSemilattice a, BoundedJoinSemilattice a') => TopOf (t a) (t a') where
+   topOf = (<$>) (const bot >>> neg)
+
+-- Specialises botOf and topOf but omits the lattice constraint.
+erase :: forall t a. Functor t => t a -> Raw t
+erase = (<$>) (const unit)
+
+-- Give ∧ and ∨ same associativity and precedence as * and +
+infixl 7 meet as ∧
+infixl 6 join as ∨
+
+type 𝔹 = Boolean
+type Raw (c :: Type -> Type) = c Unit
+
+instance (JoinSemilattice a, JoinSemilattice b) => JoinSemilattice (a × b) where
+   join ab = definedJoin ab
+   maybeJoin (a × a') (b × b') = maybeJoin a b `lift2 (×)` maybeJoin a' b'
+   neg = (<$>) neg
+
+instance JoinSemilattice a => JoinSemilattice (Pair a) where
+   join ab = definedJoin ab
+   maybeJoin (Pair a1 a1') (Pair a2 a2') = Pair <$> maybeJoin a1 a2 <*> maybeJoin a1' a2'
+   neg = (<$>) neg
+
+instance JoinSemilattice a => JoinSemilattice (List a) where
+   join xs = definedJoin xs
+   maybeJoin xs ys
+      | (length xs :: Int) == length ys = sequence (zipWith maybeJoin xs ys)
+      | otherwise = report "Mismatched list lengths"
+   neg = (<$>) neg
+
+instance JoinSemilattice a => JoinSemilattice (Dict a) where
+   join = unionWith (∨) -- faster than definedJoin
+   maybeJoin m m' = foldM mayFailUpdate m (toUnfoldable m' :: List (Var × a))
+   neg = (<$>) neg
+
+mayFailUpdate :: forall a. JoinSemilattice a => Dict a -> Var × a -> MayFail (Dict a)
+mayFailUpdate m (k × v) =
+   case lookup k m of
+      Nothing -> pure (insert k v m)
+      Just v' -> update <$> (const <$> Just <$> maybeJoin v' v) <@> k <@> m
+
+instance JoinSemilattice a => JoinSemilattice (Array a) where
+   join xs = definedJoin xs
+   maybeJoin xs ys
+      | length xs == (length ys :: Int) = sequence (A.zipWith maybeJoin xs ys)
+      | otherwise = report "Mismatched array lengths"
+   neg = (<$>) neg
+
+-- To express as Expandable (t :: Type -> Type) requires functor composition..
+class Expandable t u | t -> u where
+   expand :: t -> u -> t
+
+instance Expandable (t a) (Raw t) => Expandable (a × t a) (Unit × Raw t) where
+   expand (α × a) (_ × a') = α × expand a a'
+
+instance Expandable t u => Expandable (Pair t) (Pair u) where
+   expand (Pair x x') (Pair y y') = Pair (expand x y) (expand x' y')
+
+instance (BotOf u t, Expandable t u) => Expandable (Dict t) (Dict u) where
+   expand kvs kvs' =
+      assert (keys kvs `subset` keys kvs') $
+         (kvs `intersectionWith expand` kvs') `union` ((kvs' `difference` kvs) <#> botOf)
+
+instance Expandable t u => Expandable (List t) (List u) where
+   expand xs ys = zipWith expand xs ys
+
+instance Expandable t u => Expandable (Array t) (Array u) where
+   expand xs ys = A.zipWith expand xs ys

--- a/src/Pretty2.purs
+++ b/src/Pretty2.purs
@@ -1,0 +1,259 @@
+module Pretty2 (class Pretty, class ToList, pretty, prettyP, toList, module P) where
+
+import Prelude hiding (absurd, between)
+
+import Bindings (Bind, Var, (↦))
+import Data.Exists (runExists)
+import Data.Foldable (class Foldable)
+import Data.List (List(..), (:), fromFoldable, null)
+import Data.List.NonEmpty (NonEmptyList)
+import Data.List.NonEmpty (toList) as NEL
+import Data.Profunctor.Choice ((|||))
+import Data.Profunctor.Strong (first)
+import Data.String (Pattern(..), contains) as Data.String
+import DataType (Ctr, cCons, cNil, cPair, showCtr)
+import Dict (Dict)
+import Dict (toUnfoldable) as D
+import Expr2 (Cont(..), Elim(..))
+import Expr2 (Expr(..), VarDef(..)) as E
+import Parse (str)
+import SExpr2 (SExpr(..), ListRest(..), ListRestPattern(..), Pattern(..), Qualifier(..), VarDef(..)) as S
+import Text.Pretty (Doc, atop, beside, empty, hcat, render, text)
+import Text.Pretty (render) as P
+import Util (type (+), type (×), Endo, absurd, assert, error, intersperse, (×))
+import Util.Pair (toTuple)
+import Val2 (Fun(..), Val(..)) as V
+import Val2 (class Highlightable, ForeignOp', Fun, Val, highlightIf)
+
+infixl 5 beside as :<>:
+
+prettyP :: forall d. Pretty d => d -> String
+prettyP = pretty >>> render
+
+between :: Doc -> Doc -> Endo Doc
+between l r doc = l :<>: doc :<>: r
+
+brackets :: Endo Doc
+brackets = between (text str.lBracket) (text str.rBracket)
+
+comma :: Doc
+comma = text ","
+
+semi :: Doc
+semi = text ";"
+
+space :: Doc
+space = text " "
+
+hspace :: forall f. Foldable f => f Doc -> Doc
+hspace = fromFoldable >>> intersperse space >>> hcat
+
+hcomma :: forall f. Foldable f => f Doc -> Doc
+hcomma = fromFoldable >>> intersperse (comma :<>: space) >>> hcat
+
+parens :: Endo Doc
+parens = between (text "(") (text ")")
+
+emptyDoc :: Doc
+emptyDoc = empty 0 0
+
+class ToList a where
+   toList :: a -> List a
+
+class ToPair a where
+   toPair :: a -> a × a
+
+instance ToPair (E.Expr a) where
+   toPair (E.Constr _ c (e : e' : Nil)) | c == cPair = e × e'
+   toPair _ = error absurd
+
+instance ToPair (Val a) where
+   toPair (V.Constr _ c (v : v' : Nil)) | c == cPair = v × v'
+   toPair _ = error absurd
+
+class Pretty p where
+   pretty :: p -> Doc
+
+instance Pretty String where
+   pretty = text
+
+vert :: forall f. Foldable f => Doc -> f Doc -> Doc
+vert delim = fromFoldable >>> vert'
+   where
+   vert' :: List Doc -> Doc
+   vert' Nil = emptyDoc
+   vert' (x : Nil) = x
+   vert' (x : y : xs) = atop (x :<>: delim) (vert' (y : xs))
+
+prettyCtr :: Ctr -> Doc
+prettyCtr = showCtr >>> text
+
+-- Cheap hack; revisit.
+prettyParensOpt :: forall a. Pretty a => a -> Doc
+prettyParensOpt x =
+   if Data.String.contains (Data.String.Pattern " ") (render doc) then parens doc
+   else doc
+   where
+   doc = pretty x
+
+nil :: Doc
+nil = text (str.lBracket <> str.rBracket)
+
+prettyConstr :: forall d a. Pretty d => Highlightable a => a -> Ctr -> List d -> Doc
+prettyConstr α c (x : y : ys)
+   | c == cPair = assert (null ys) $ highlightIf α $ parens (hcomma [ pretty x, pretty y ])
+prettyConstr α c ys
+   | c == cNil = assert (null ys) $ highlightIf α nil
+prettyConstr α c (x : y : ys)
+   | c == cCons = assert (null ys) $ parens (hspace [ pretty x, highlightIf α $ text ":", pretty y ])
+prettyConstr α c xs = hspace (highlightIf α (prettyCtr c) : (prettyParensOpt <$> xs))
+
+prettyRecordOrDict
+   :: forall d b a
+    . Pretty d
+   => Highlightable a
+   => Doc
+   -> Endo Doc
+   -> (b -> Doc)
+   -> a
+   -> List (b × d)
+   -> Doc
+prettyRecordOrDict sep bracify prettyKey α xvs =
+   xvs <#> first prettyKey <#> (\(x × v) -> hspace [ x :<>: sep, pretty v ])
+      # hcomma >>> bracify >>> highlightIf α
+
+prettyDict :: forall d b a. Pretty d => Highlightable a => (b -> Doc) -> a -> List (b × d) -> Doc
+prettyDict = between (text str.dictLBracket) (text str.dictRBracket) # prettyRecordOrDict (text str.colonEq)
+
+prettyRecord :: forall d b a. Pretty d => Highlightable a => (b -> Doc) -> a -> List (b × d) -> Doc
+prettyRecord = between (text "{") (text "}") # prettyRecordOrDict (text str.colon)
+
+instance Highlightable a => Pretty (E.Expr a) where
+   pretty (E.Var x) = text x
+   pretty (E.Int α n) = highlightIf α (text (show n))
+   pretty (E.Float _ n) = text (show n)
+   pretty (E.Str _ str) = text (show str)
+   pretty (E.Record α xes) = prettyRecord text α (xes # D.toUnfoldable)
+   pretty (E.Dictionary α ees) = prettyDict pretty α (ees <#> toTuple)
+   pretty (E.Constr α c es) = prettyConstr α c es
+   pretty (E.Matrix _ _ _ _) = error "todo"
+   pretty (E.Lambda σ) = hspace [ text str.fun, pretty σ ]
+   pretty (E.Op op) = parens (text op)
+   pretty (E.Let (E.VarDef σ e) e') = atop (hspace [ text str.let_, pretty σ, text str.equals, pretty e, text str.in_ ])
+      (pretty e')
+   pretty (E.LetRec δ e) = atop (hspace [ text str.let_, pretty δ, text str.in_ ]) (pretty e)
+   pretty (E.Project _ _) = error "todo"
+   pretty (E.App e e') = hspace [ pretty e, pretty e' ]
+   pretty (E.Sugar s) = error "todo"
+
+instance Highlightable a => Pretty (Dict (Elim a)) where
+   pretty = D.toUnfoldable >>> go
+      where
+      go :: List (Var × Elim a) -> Doc
+      go Nil = error absurd -- non-empty
+      go (xσ : Nil) = pretty xσ
+      go (xσ : δ) = atop (go δ :<>: semi) (pretty xσ)
+
+instance Highlightable a => Pretty (Bind (Elim a)) where
+   pretty (x ↦ σ) = hspace [ text x, text str.equals, pretty σ ]
+
+instance Highlightable a => Pretty (Cont a) where
+   pretty ContNone = emptyDoc
+   pretty (ContExpr e) = pretty e
+   pretty (ContElim σ) = pretty σ
+
+instance Highlightable a => Pretty (Ctr × Cont a) where
+   pretty (c × κ) = hspace [ text (showCtr c), text str.rArrow, pretty κ ]
+
+instance Highlightable a => Pretty (Elim a) where
+   pretty (ElimVar x κ) = hspace [ text x, text str.rArrow, pretty κ ]
+   pretty (ElimConstr κs) = hcomma (pretty <$> κs) -- looks dodgy
+   pretty (ElimRecord _ _) = error "todo"
+
+instance Highlightable a => Pretty (Val a) where
+   pretty (V.Int α n) = highlightIf α (text (show n))
+   pretty (V.Float α n) = highlightIf α (text (show n))
+   pretty (V.Str α str) = highlightIf α (text (show str))
+   pretty (V.Record α xvs) = prettyRecord text α (xvs # D.toUnfoldable)
+   pretty (V.Dictionary α svs) = prettyDict
+      (\(s × β) -> highlightIf β (text (show s)))
+      α
+      (svs # D.toUnfoldable <#> \(s × (β × v)) -> (s × β) × v)
+   pretty (V.Constr α c vs) = prettyConstr α c vs
+   pretty (V.Matrix _ (vss × _ × _)) = vert comma (((<$>) pretty >>> hcomma) <$> vss)
+   pretty (V.Fun φ) = pretty φ
+
+instance Highlightable a => Pretty (Fun a) where
+   pretty (V.Closure _ _ _ _) = text "<closure>"
+   pretty (V.Foreign φ _) = parens (runExists pretty φ)
+   pretty (V.PartialConstr α c vs) = prettyConstr α c vs
+
+instance Pretty (ForeignOp' t) where
+   pretty _ = text "<extern op>" -- TODO
+
+-- Surface language
+
+instance Highlightable a => ToPair (S.SExpr a) where
+--    toPair (S.Constr _ c (s : s' : Nil)) | c == cPair = s × s'
+   toPair s = error ("Not a pair: " <> prettyP s)
+
+instance Highlightable a => Pretty (S.SExpr a) where
+   pretty (S.BinaryApp s op s') = parens (hspace [ pretty s, text op, pretty s' ])
+   pretty (S.MatchAs s bs) = atop (hspace [ text str.match, pretty s, text str.as ]) (vert semi (pretty <$> bs))
+   pretty (S.IfElse s1 s2 s3) =
+      hspace [ text str.if_, pretty s1, text str.then_, pretty s2, text str.else_, pretty s3 ]
+   pretty (S.ListEmpty α) = highlightIf α nil
+   pretty (S.ListNonEmpty α e l) = highlightIf α (text str.lBracket) :<>: pretty e :<>: pretty l
+   pretty (S.ListEnum s s') = brackets (hspace [ pretty s, text str.ellipsis, pretty s' ])
+   pretty (S.ListComp α s qs) = highlightIf α $ brackets (hspace [ pretty s, text str.bar, hcomma (pretty <$> qs) ])
+   pretty (S.Let ds s) = atop (hspace [ text str.let_, vert semi (pretty <$> ds) ])
+      (hspace [ text str.in_, pretty s ])
+   pretty (S.LetRec h s) = atop (hspace [ text str.let_, vert semi (pretty <$> h) ])
+      (hspace [ text str.in_, pretty s ])
+
+instance Highlightable a => Pretty (S.ListRest a) where
+   pretty (S.End α) = highlightIf α (text str.rBracket)
+   pretty (S.Next α s l) = hspace [ highlightIf α comma, pretty s :<>: pretty l ]
+
+instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × S.SExpr a)) where
+   pretty (x × b) = hspace [ text x, pretty b ]
+
+instance Highlightable a => Pretty (NonEmptyList S.Pattern × S.SExpr a) where
+   pretty (ps × s) = hspace ((pretty <$> NEL.toList ps) <> (text str.equals : pretty s : Nil))
+
+instance Highlightable a => Pretty (S.VarDef a) where
+   pretty (S.VarDef p s) = hspace [ pretty p, text str.equals, pretty s ]
+
+instance Highlightable a => Pretty (S.Pattern × S.SExpr a) where
+   pretty (p × s) = pretty p :<>: text str.lArrow :<>: pretty s
+
+instance Highlightable a => Pretty (S.Pattern × E.Expr a) where
+   pretty (p × e) = pretty p :<>: text str.lArrow :<>: pretty e
+
+instance Highlightable a => Pretty (S.Qualifier a) where
+   pretty (S.Guard e) = pretty e
+   pretty (S.Generator p e) = hspace [ pretty p, text str.lArrow, pretty e ]
+   pretty (S.Declaration (S.VarDef p e)) = hspace [ text str.let_, pretty p, text str.equals, pretty e ]
+
+instance (Pretty a, Pretty b) => Pretty (a + b) where
+   pretty = pretty ||| pretty
+
+instance Pretty S.Pattern where
+   pretty (S.PVar x) = text x
+   pretty (S.PConstr c ps) = prettyConstr false c ps
+   pretty (S.PRecord xps) = prettyRecord text false xps
+   pretty (S.PListEmpty) = nil
+   pretty (S.PListNonEmpty s l) = text str.lBracket :<>: pretty s :<>: pretty l
+
+instance ToList S.Pattern where
+   toList (S.PConstr c (p : p' : Nil)) | c == cCons = p : toList p'
+   toList (S.PConstr c Nil) | c == cNil = Nil
+   toList _ = error absurd
+
+instance ToPair S.Pattern where
+   toPair (S.PConstr c (p : p' : Nil)) | c == cPair = p × p'
+   toPair _ = error absurd
+
+instance Pretty S.ListRestPattern where
+   pretty S.PEnd = text str.rBracket
+   pretty (S.PNext s l) = hspace [ comma, pretty s :<>: pretty l ]

--- a/src/Pretty2.purs
+++ b/src/Pretty2.purs
@@ -194,7 +194,7 @@ instance Pretty (ForeignOp' t) where
 -- Surface language
 
 instance Highlightable a => ToPair (S.SExpr a) where
---    toPair (S.Constr _ c (s : s' : Nil)) | c == cPair = s × s'
+   --    toPair (S.Constr _ c (s : s' : Nil)) | c == cPair = s × s'
    toPair s = error ("Not a pair: " <> prettyP s)
 
 instance Highlightable a => Pretty (S.SExpr a) where

--- a/src/Pretty2.purs
+++ b/src/Pretty2.purs
@@ -144,7 +144,7 @@ instance Highlightable a => Pretty (E.Expr a) where
    pretty (E.LetRec δ e) = atop (hspace [ text str.let_, pretty δ, text str.in_ ]) (pretty e)
    pretty (E.Project _ _) = error "todo"
    pretty (E.App e e') = hspace [ pretty e, pretty e' ]
-   pretty (E.Sugar s) = error "todo"
+   pretty (E.Sugar _) = error "todo"
 
 instance Highlightable a => Pretty (Dict (Elim a)) where
    pretty = D.toUnfoldable >>> go
@@ -215,10 +215,10 @@ instance Highlightable a => Pretty (S.ListRest a) where
    pretty (S.End α) = highlightIf α (text str.rBracket)
    pretty (S.Next α s l) = hspace [ highlightIf α comma, pretty s :<>: pretty l ]
 
-instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × S.SExpr a)) where
+instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × E.Expr a)) where
    pretty (x × b) = hspace [ text x, pretty b ]
 
-instance Highlightable a => Pretty (NonEmptyList S.Pattern × S.SExpr a) where
+instance Highlightable a => Pretty (NonEmptyList S.Pattern × E.Expr a) where
    pretty (ps × s) = hspace ((pretty <$> NEL.toList ps) <> (text str.equals : pretty s : Nil))
 
 instance Highlightable a => Pretty (S.VarDef a) where

--- a/src/Pretty2.purs
+++ b/src/Pretty2.purs
@@ -144,7 +144,7 @@ instance Highlightable a => Pretty (E.Expr a) where
    pretty (E.LetRec δ e) = atop (hspace [ text str.let_, pretty δ, text str.in_ ]) (pretty e)
    pretty (E.Project _ _) = error "todo"
    pretty (E.App e e') = hspace [ pretty e, pretty e' ]
-   pretty (E.Sugar s) = error "todo"
+   pretty (E.Sugar _) = error "todo"
 
 instance Highlightable a => Pretty (Dict (Elim a)) where
    pretty = D.toUnfoldable >>> go
@@ -215,10 +215,9 @@ instance Highlightable a => Pretty (S.ListRest a) where
    pretty (S.End α) = highlightIf α (text str.rBracket)
    pretty (S.Next α s l) = hspace [ highlightIf α comma, pretty s :<>: pretty l ]
 
-instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × S.SExpr a)) where
+instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × E.Expr a)) where
    pretty (x × b) = hspace [ text x, pretty b ]
-
-instance Highlightable a => Pretty (NonEmptyList S.Pattern × S.SExpr a) where
+instance Highlightable a => Pretty (NonEmptyList S.Pattern × E.Expr a) where
    pretty (ps × s) = hspace ((pretty <$> NEL.toList ps) <> (text str.equals : pretty s : Nil))
 
 instance Highlightable a => Pretty (S.VarDef a) where

--- a/src/Pretty2.purs
+++ b/src/Pretty2.purs
@@ -217,10 +217,7 @@ instance Highlightable a => Pretty (S.ListRest a) where
 
 instance Highlightable a => Pretty (String × (NonEmptyList S.Pattern × E.Expr a)) where
    pretty (x × b) = hspace [ text x, pretty b ]
-<<<<<<< HEAD
-=======
 
->>>>>>> sugar-existential-roly
 instance Highlightable a => Pretty (NonEmptyList S.Pattern × E.Expr a) where
    pretty (ps × s) = hspace ((pretty <$> NEL.toList ps) <> (text str.equals : pretty s : Nil))
 

--- a/src/Primitive2.purs
+++ b/src/Primitive2.purs
@@ -1,0 +1,293 @@
+module Primitive2 where
+
+import Prelude hiding (absurd, apply, div, top)
+
+import Data.Either (Either(..))
+import Data.Exists (mkExists)
+import Data.Int (toNumber)
+import Data.List (List(..), (:))
+import Data.Profunctor.Choice ((|||))
+import Data.Tuple (fst)
+import DataType (cFalse, cPair, cTrue)
+import Dict (Dict)
+import Lattice2 (Raw, (∧), bot, erase, top)
+import Partial.Unsafe (unsafePartial)
+import Pretty2 (prettyP)
+import Util (type (+), type (×), error, (×))
+import Val2 (class Ann, ForeignOp'(..), Fun(..), MatrixRep, OpBwd, OpFwd, Val(..))
+
+-- Mediate between values of annotation type a and (potential) underlying datatype d, analogous to
+-- pattern-matching and construction for data types. Wasn't able to make a typeclass version of this
+-- work with the required higher-rank polymorphism.
+type ToFrom d a =
+   { constr :: Ann a => d × a -> Val a
+   , constr_bwd :: Ann a => Val a -> d × a -- equivalent to match (except at Val)
+   , match :: Ann a => Val a -> d × a
+   }
+
+-- Analogous to "variable" case in pattern-matching (or "use existing subvalue" case in construction).
+val :: forall a. ToFrom (Val a) a
+val =
+   { constr: fst -- construction rights not required
+   , constr_bwd: (_ × bot) -- return unit of disjunction rather than conjunction
+   , match: (_ × top) -- construction rights always provided
+   }
+
+int :: forall a. ToFrom Int a
+int =
+   { constr: \(n × α) -> Int α n
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => _
+   match' (Int α n) = n × α
+   match' v = error ("Int expected; got " <> prettyP v)
+
+number :: forall a. ToFrom Number a
+number =
+   { constr: \(n × α) -> Float α n
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => _
+   match' (Float α n) = n × α
+   match' v = error ("Float expected; got " <> prettyP v)
+
+string :: forall a. ToFrom String a
+string =
+   { constr: \(str × α) -> Str α str
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => _
+   match' (Str α str) = str × α
+   match' v = error ("Str expected; got " <> prettyP v)
+
+intOrNumber :: forall a. ToFrom (Int + Number) a
+intOrNumber =
+   { constr: case _ of
+        Left n × α -> Int α n
+        Right n × α -> Float α n
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => Val a -> (Int + Number) × a
+   match' (Int α n) = Left n × α
+   match' (Float α n) = Right n × α
+   match' v = error ("Int or Float expected; got " <> prettyP v)
+
+intOrNumberOrString :: forall a. ToFrom (Int + Number + String) a
+intOrNumberOrString =
+   { constr: case _ of
+        Left n × α -> Int α n
+        Right (Left n) × α -> Float α n
+        Right (Right str) × α -> Str α str
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => Val a -> (Int + Number + String) × a
+   match' (Int α n) = Left n × α
+   match' (Float α n) = Right (Left n) × α
+   match' (Str α str) = Right (Right str) × α
+   match' v = error ("Int, Float or Str expected; got " <> prettyP v)
+
+intPair :: forall a. ToFrom ((Int × a) × (Int × a)) a
+intPair =
+   { constr: \((nβ × mβ') × α) -> Constr α cPair (int.constr nβ : int.constr mβ' : Nil)
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => Val a -> ((Int × a) × (Int × a)) × a
+   match' (Constr α c (v : v' : Nil)) | c == cPair = (int.match v × int.match v') × α
+   match' v = error ("Pair expected; got " <> prettyP v)
+
+matrixRep :: forall a. ToFrom (Array (Array (Val a)) × (Int × a) × (Int × a)) a
+matrixRep =
+   { constr: \(r × α) -> Matrix α r
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => Val a -> MatrixRep a × a
+   match' (Matrix α r) = r × α
+   match' v = error ("Matrix expected; got " <> prettyP v)
+
+record :: forall a. ToFrom (Dict (Val a)) a
+record =
+   { constr: \(xvs × α) -> Record α xvs
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => _
+   match' (Record α xvs) = xvs × α
+   match' v = error ("Record expected; got " <> prettyP v)
+
+boolean :: forall a. ToFrom Boolean a
+boolean =
+   { constr: case _ of
+        true × α -> Constr α cTrue Nil
+        false × α -> Constr α cFalse Nil
+   , constr_bwd: match'
+   , match: match'
+   }
+   where
+   match' :: Ann a => Val a -> Boolean × a
+   match' (Constr α c Nil)
+      | c == cTrue = true × α
+      | c == cFalse = false × α
+   match' v = error ("Boolean expected; got " <> prettyP v)
+
+class IsZero a where
+   isZero :: a -> Boolean
+
+instance IsZero Int where
+   isZero = ((==) 0)
+
+instance IsZero Number where
+   isZero = ((==) 0.0)
+
+instance (IsZero a, IsZero b) => IsZero (a + b) where
+   isZero = isZero ||| isZero
+
+-- Need to be careful about type variables escaping higher-rank quantification.
+type Unary i o a =
+   { i :: ToFrom i a
+   , o :: ToFrom o a
+   , fwd :: i -> o
+   }
+
+type Binary i1 i2 o a =
+   { i1 :: ToFrom i1 a
+   , i2 :: ToFrom i2 a
+   , o :: ToFrom o a
+   , fwd :: i1 -> i2 -> o
+   }
+
+type BinaryZero i o a =
+   { i :: ToFrom i a
+   , o :: ToFrom o a
+   , fwd :: i -> i -> o
+   }
+
+unary :: forall i o a'. (forall a. Unary i o a) -> Val a'
+unary op =
+   Fun $ flip Foreign Nil
+      $ mkExists
+      $ ForeignOp' { arity: 1, op: unsafePartial fwd, op_bwd: unsafePartial bwd }
+   where
+   fwd :: Partial => OpFwd (Raw Val)
+   fwd (v : Nil) = pure $ erase v × op.o.constr (op.fwd x × α)
+      where
+      x × α = op.i.match v
+
+   bwd :: Partial => OpBwd (Raw Val)
+   bwd (u × v) = op.i.constr (x × α) : Nil
+      where
+      _ × α = op.o.constr_bwd v
+      (x × _) = op.i.match u
+
+binary :: forall i1 i2 o a'. (forall a. Binary i1 i2 o a) -> Val a'
+binary op =
+   Fun $ flip Foreign Nil
+      $ mkExists
+      $ ForeignOp' { arity: 2, op: unsafePartial fwd, op_bwd: unsafePartial bwd }
+   where
+   fwd :: Partial => OpFwd (Raw Val × Raw Val)
+   fwd (v1 : v2 : Nil) = pure $ (erase v1 × erase v2) × op.o.constr (op.fwd x y × (α ∧ β))
+      where
+      (x × α) × (y × β) = op.i1.match v1 × op.i2.match v2
+
+   bwd :: Partial => OpBwd (Raw Val × Raw Val)
+   bwd ((u1 × u2) × v) = op.i1.constr (x × α) : op.i2.constr (y × α) : Nil
+      where
+      _ × α = op.o.constr_bwd v
+      (x × _) × (y × _) = op.i1.match u1 × op.i2.match u2
+
+-- If both are zero, depend only on the first.
+binaryZero :: forall i o a'. IsZero i => (forall a. BinaryZero i o a) -> Val a'
+binaryZero op =
+   Fun $ flip Foreign Nil
+      $ mkExists
+      $ ForeignOp' { arity: 2, op: unsafePartial fwd, op_bwd: unsafePartial bwd }
+   where
+   fwd :: Partial => OpFwd (Raw Val × Raw Val)
+   fwd (v1 : v2 : Nil) =
+      pure $ (erase v1 × erase v2) ×
+         op.o.constr (op.fwd x y × if isZero x then α else if isZero y then β else α ∧ β)
+      where
+      (x × α) × (y × β) = op.i.match v1 × op.i.match v2
+
+   bwd :: Partial => OpBwd (Raw Val × Raw Val)
+   bwd ((u1 × u2) × v) = op.i.constr (x × β1) : op.i.constr (y × β2) : Nil
+      where
+      _ × α = op.o.constr_bwd v
+      (x × _) × (y × _) = op.i.match u1 × op.i.match u2
+      β1 × β2 =
+         if isZero x then α × bot
+         else if isZero y then bot × α
+         else α × α
+
+class As a b where
+   as :: a -> b
+
+union1 :: forall a1 b. (a1 -> b) -> (Number -> b) -> a1 + Number -> b
+union1 f _ (Left x) = f x
+union1 _ g (Right x) = g x
+
+-- Biased towards g: if arguments are of mixed types, we try to coerce to an application of g.
+union
+   :: forall a1 b1 c1 a2 b2 c2 c
+    . As c1 c
+   => As c2 c
+   => As a1 a2
+   => As b1 b2
+   => (a1 -> b1 -> c1)
+   -> (a2 -> b2 -> c2)
+   -> a1 + a2
+   -> b1 + b2
+   -> c
+union f _ (Left x) (Left y) = as (f x y)
+union _ g (Left x) (Right y) = as (g (as x) y)
+union _ g (Right x) (Right y) = as (g x y)
+union _ g (Right x) (Left y) = as (g x (as y))
+
+-- Helper to avoid some explicit type annotations when defining primitives.
+unionStr
+   :: forall a b
+    . As a a
+   => As b String
+   => (b -> b -> a)
+   -> (String -> String -> a)
+   -> b + String
+   -> b + String
+   -> a
+unionStr = union
+
+instance asIntIntOrNumber :: As Int (Int + a) where
+   as = Left
+
+instance asNumberIntOrNumber :: As Number (a + Number) where
+   as = Right
+
+instance asIntNumber :: As Int Number where
+   as = toNumber
+
+instance asBooleanBoolean :: As Boolean Boolean where
+   as = identity
+
+instance asNumberString :: As Number String where
+   as _ = error "Non-uniform argument types"
+
+instance asIntNumberOrString :: As Int (Number + a) where
+   as = toNumber >>> Left
+
+instance asIntorNumberNumber :: As (Int + Number) Number where
+   as (Left n) = as n
+   as (Right n) = n

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -8,9 +8,8 @@ import Data.List (List)
 import Data.List.NonEmpty (NonEmptyList)
 import DataType (Ctr)
 import Expr2 (class Desugarable, Expr)
-import Lattice (class JoinSemilattice, definedJoin, neg)
+import Lattice2 (class JoinSemilattice, definedJoin, neg)
 import Util (type (×), (×), type (+), error, unimplemented)
-import Util.Pair (Pair)
 
 
 instance Desugarable SExpr a where
@@ -18,19 +17,7 @@ instance Desugarable SExpr a where
 
 -- Surface language expressions.
 data SExpr a
-   = Var Var
-   | Op Var
-   | Int a Int
-   | Float a Number
-   | Str a String
-   | Constr a Ctr (List (Expr a))
-   | Record a (List (Bind (Expr a)))
-   | Dictionary a (List (Pair (Expr a)))
-   | Matrix a (Expr a) (Var × Var) (Expr a)
-   | Lambda (NonEmptyList (Branch a))
-   | Project (Expr a) Var
-   | App (Expr a) (Expr a)
-   | BinaryApp (Expr a) Var (Expr a)
+   = BinaryApp (Expr a) Var (Expr a)
    | MatchAs (Expr a) (NonEmptyList (Pattern × Expr a))
    | IfElse (Expr a) (Expr a) (Expr a)
    | ListEmpty a -- called [] in the paper

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -4,16 +4,53 @@ import Prelude
 
 import Bindings (Bind, Var)
 import Data.Either (Either(..))
-import Data.List (List)
+import Data.List (List(..), (:))
 import Data.List.NonEmpty (NonEmptyList)
-import DataType (Ctr)
-import Expr2 (class Desugarable, Expr)
+import DataType (Ctr, cFalse, cNil, cTrue, cCons)
+import Dict as D
+import Expr2 (Expr(..)) as E
+import Expr2 (class Desugarable, Cont(..), Elim(..), Expr, desug, mkSugar)
 import Lattice2 (class JoinSemilattice, definedJoin, neg)
 import Util (type (×), (×), type (+), error, unimplemented)
 
+scons :: forall a. a -> E.Expr a -> E.Expr a -> E.Expr a
+scons ann head rest = E.Constr ann cCons (head : rest : Nil)
 
 instance Desugarable SExpr a where
-    desug _ = error "todo"
+    desug (BinaryApp l op r)           = E.App (E.App (E.Op op) l) r 
+    desug (MatchAs guard patterns)     = E.App (E.Lambda (clauseDS patterns)) guard 
+                                         where
+                                            processClause :: forall a. Pattern × Expr a -> Elim a
+                                            processClause (pattern × expr) =  
+                                                let cont = ContExpr expr in error "todo"
+                                            clauseDS :: forall a. NonEmptyList (Pattern × Expr a) -> Elim a
+                                            clauseDS clauses = error "todo"
+
+    desug (IfElse guard trueP falseP)  = E.App (E.Lambda (elimBool (ContExpr trueP) (ContExpr falseP))) guard
+                                         where 
+                                             elimBool :: forall a'. Cont a' -> Cont a' -> Elim a'
+                                             elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
+    
+    desug (ListEmpty ann)              = E.Constr ann cNil Nil
+    desug (ListNonEmpty ann head rest) = scons ann head (mkSugar rest)
+    desug (ListEnum head last)         = E.App (E.App (E.Var "enumFromTo") head) last
+    desug (ListComp ann head quals)    = error "todo"
+    desug (Let defs exp)               = error "todo"
+    desug (LetRec recdefs exp)         = error "todo"
+instance Desugarable ListRest a where
+    desug (End ann) = E.Constr ann cNil Nil
+    desug (Next ann head rest) = scons ann (desug head) (mkSugar rest)
+
+-- clause :: forall a. Pattern × Expr a -> Elim a
+-- clause cl = 
+
+desugPWithC :: forall a. Pattern -> Cont a -> Elim a
+desugPWithC (PVar x)              k = ElimVar x k
+desugPWithC (PConstr c ps)        k = error "todo"
+desugPWithC (PRecord bps)         k = error "todo"
+desugPWithC  PListEmpty           k = error "todo"
+desugPWithC (PListNonEmpty p lrp) k = error "todo" 
+
 
 -- Surface language expressions.
 data SExpr a

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -1,23 +1,25 @@
 module SExpr2 where
 
 import Prelude hiding (absurd, join)
+import Prelude (join) as P
 import Bindings (Var, Bind, varAnon, (↦), keys)
 import Data.Either (Either(..))
-import Data.Foldable (foldl)
+import Data.Foldable (foldl, foldM)
 import Data.Function (applyN, on)
-import Data.List (List(..), (:), (\\), sortBy)
+import Data.List (List(..), (:), (\\), sortBy, length)
 import Data.List (singleton) as L
-import Data.List.NonEmpty (NonEmptyList(..), groupBy, head)
+import Data.List.NonEmpty (NonEmptyList(..), groupBy, head, toList)
 import Data.NonEmpty ((:|))
 import Data.Set (toUnfoldable) as S
-import Data.Tuple (fst, snd)
-import DataType (Ctr, arity, cCons, cFalse, cNil, cTrue, ctrs, dataTypeFor)
-import Dict (asSingletonMap)
+import Data.Traversable (traverse)
+import Data.Tuple (fst, snd, uncurry)
+import DataType (Ctr, arity, cCons, cFalse, cNil, cTrue, checkArity, ctrs, dataTypeFor)
+import Dict (asSingletonMap, Dict(..))
 import Dict as D
-import Expr2 (Expr(..), RecDefs, VarDef(..)) as E
-import Expr2 (class Desugarable, class Desugarable2, Cont(..), Elim(..), Expr, asElim, desug, mkSugar)
-import Lattice2 (class JoinSemilattice, definedJoin, join, neg)
-import Util (type (×), (×), type (+), absurd, error, unimplemented, successful)
+import Expr2 (class Desugarable, class Desugarable2, Cont(..), Elim(..), Expr, asElim, desug, thunkSugar)
+import Expr2 (Expr(..), RecDefs, VarDef(..), Module(..)) as E
+import Lattice2 (class JoinSemilattice, definedJoin, join, neg, maybeJoin )
+import Util (type (×), (×), type (+), absurd, error, unimplemented, successful, MayFail)
 
 scons :: forall a. a -> E.Expr a -> E.Expr a -> E.Expr a
 scons ann head tail = E.Constr ann cCons (head : tail : Nil)
@@ -25,22 +27,20 @@ scons ann head tail = E.Constr ann cCons (head : tail : Nil)
 snil :: forall a. a -> E.Expr a
 snil ann = E.Constr ann cNil Nil
 
-elimBool :: forall a'. Cont a' -> Cont a' -> Elim a'
-elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
--- instance Desugarable2 SExpr where
---     desug2 = exprFwd
+instance Desugarable2 SExpr where
+    desug2 = exprFwd
 instance Desugarable SExpr where
    -- Correct
    desug (BinaryApp l op r) = E.App (E.App (E.Op op) l) r
-   -- Correct dependent on "clauses" which is meant to be equivalent to branchesFwd_uncurried
-   desug (MatchAs guard patterns) = E.App (E.Lambda (branchesFwd_uncurried patterns)) guard
+   -- Correct dependent on "clauses" which is meant to be equivalent to branchesFwd2_uncurried
+   desug (MatchAs guard patterns) = E.App (E.Lambda (branchesFwd2_uncurried patterns)) guard
    -- Correct
    desug (IfElse guard trueP falseP) = E.App (E.Lambda (elimBool (ContExpr trueP) (ContExpr falseP))) guard
    -- Correct
    desug (ListEmpty ann) = E.Constr ann cNil Nil
 
-   -- Needs to be checked but either this is correct or, we need mkSugar in parsing
-   desug (ListNonEmpty ann head rest) = scons ann head (mkSugar rest)
+   -- Needs to be checked but either this is correct or, we need thunkSugar in parsing
+   desug (ListNonEmpty ann head rest) = scons ann head (thunkSugar rest)
 
    -- Correct
    desug (ListEnum head last) = E.App (E.App (E.Var "enumFromTo") head) last
@@ -48,25 +48,25 @@ instance Desugarable SExpr where
       scons ann2 body (snil ann2) -- Should be correct
    -- Need to check this one
    desug (ListComp ann body (NonEmptyList (q :| Nil))) =
-      desug (ListComp ann body (NonEmptyList (q :| Guard (E.Constr ann cTrue Nil) : Nil))) -- may need to be mkSugar
+      desug (ListComp ann body (NonEmptyList (q :| Guard (E.Constr ann cTrue Nil) : Nil))) -- may need to be thunkSugar
    -- Need to check
    desug (ListComp ann body (NonEmptyList (Guard s :| q : qs))) =
       let
-         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+         e = thunkSugar (ListComp ann body (NonEmptyList (q :| qs)))
       in
          E.App (E.Lambda (elimBool (ContExpr e) (ContExpr (snil ann)))) s
-   -- Need to check the mkSugar's here
+   -- Need to check the thunkSugar's here
    desug (ListComp ann body (NonEmptyList (Declaration (VarDef pi s) :| q : qs))) =
       let
-         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-         sig = patternFwd pi (ContExpr e :: Cont _)
+         e = thunkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+         sig = patternFwd2 pi (ContExpr e :: Cont _)
       in
          E.App (E.Lambda sig) s
-   -- Need to check mkSugars
+   -- Need to check thunkSugars
    desug (ListComp ann body (NonEmptyList (Generator p s :| q : qs))) =
       let
-         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-         sig = patternFwd p (ContExpr e)
+         e = thunkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+         sig = patternFwd2 p (ContExpr e)
       in
          E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totalCont (ContElim sig) ann)))) s
    -- these 2 are correct if their auxiliaries are correct
@@ -76,7 +76,7 @@ instance Desugarable SExpr where
 -- ListRest auxiliaries
 instance Desugarable ListRest where
    desug (End ann) = E.Constr ann cNil Nil
-   desug (Next ann head rest) = scons ann head (mkSugar rest)
+   desug (Next ann head rest) = scons ann head (thunkSugar rest)
 
 -- vardefsFwd equivalent
 processVarDefs :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> E.Expr a
@@ -86,7 +86,7 @@ processVarDefs (NonEmptyList (d :| d' : ds) × exp) =
 
 --vardefFwd equivalent
 processVarDef :: forall a. JoinSemilattice a => VarDef a -> E.VarDef a
-processVarDef (VarDef pat exp) = E.VarDef (patternFwd pat (ContNone :: Cont a)) exp
+processVarDef (VarDef pat exp) = E.VarDef (patternFwd2 pat (ContNone :: Cont a)) exp
 
 -- recdefsFwd equivalent
 processRecDefs :: forall a. JoinSemilattice a => RecDefs a -> E.RecDefs a
@@ -99,45 +99,45 @@ processRecDef :: forall a. JoinSemilattice a => NonEmptyList (Clause a) -> Bind 
 processRecDef x =
    let
       pairer = (fst (head x) ↦ _) :: forall b. b -> Bind b
-      cls = branchesFwd_curried (map snd x) :: Elim a
+      cls = branchesFwd2_curried (map snd x) :: Elim a
    in
       pairer cls
 
 -- clause functions equivalent to branches
-branchFwd :: forall a. JoinSemilattice a => Pattern × Expr a -> Elim a
-branchFwd (pat × exp) = let cont = ContExpr exp in patternFwd pat cont
+branchFwd2 :: forall a. JoinSemilattice a => Pattern × Expr a -> Elim a
+branchFwd2 (pat × exp) = let cont = ContExpr exp in patternFwd2 pat cont
 
-branchesFwd_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> Elim a
-branchesFwd_curried cls =
+branchesFwd2_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> Elim a
+branchesFwd2_curried cls =
    let
-      NonEmptyList (head :| rest) = map patternsFwd cls
+      NonEmptyList (head :| rest) = map patternsFwd2 cls
    in
       foldl join head rest
 
-branchesFwd_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × Expr a) -> Elim a
-branchesFwd_uncurried cls =
+branchesFwd2_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × Expr a) -> Elim a
+branchesFwd2_uncurried cls =
    let
-      NonEmptyList (head :| rest) = map branchFwd cls
+      NonEmptyList (head :| rest) = map branchFwd2 cls
    in
       foldl join head rest
 
--- these are equivalent to patternsFwd etc
-patternFwd :: forall a. Pattern -> Cont a -> Elim a
-patternFwd (PVar x) k = ElimVar x k
-patternFwd (PConstr c ps) k =
+-- these are equivalent to patternsFwd2 etc
+patternFwd2 :: forall a. Pattern -> Cont a -> Elim a
+patternFwd2 (PVar x) k = ElimVar x k
+patternFwd2 (PConstr c ps) k =
    ElimConstr ((D.singleton c) (argPat (map Left ps) k))
-patternFwd (PRecord bps) k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
-patternFwd PListEmpty k = ElimConstr (D.singleton cNil k)
-patternFwd (PListNonEmpty p lrp) k = ElimConstr (D.singleton cCons (argPat (Left p : Right lrp : Nil) k))
+patternFwd2 (PRecord bps) k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
+patternFwd2 PListEmpty k = ElimConstr (D.singleton cNil k)
+patternFwd2 (PListNonEmpty p lrp) k = ElimConstr (D.singleton cCons (argPat (Left p : Right lrp : Nil) k))
 
-patternsFwd :: forall a. JoinSemilattice a => NonEmptyList Pattern × Expr a -> Elim a
-patternsFwd (NonEmptyList (p :| Nil) × exp) = branchFwd (p × exp)
-patternsFwd (NonEmptyList (p :| p' : ps) × exp) =
-   patternFwd p (ContExpr (E.Lambda (patternsFwd (NonEmptyList (p' :| ps) × exp))))
+patternsFwd2 :: forall a. JoinSemilattice a => NonEmptyList Pattern × Expr a -> Elim a
+patternsFwd2 (NonEmptyList (p :| Nil) × exp) = branchFwd2 (p × exp)
+patternsFwd2 (NonEmptyList (p :| p' : ps) × exp) =
+   patternFwd2 p (ContExpr (E.Lambda (patternsFwd2 (NonEmptyList (p' :| ps) × exp))))
 
 argPat :: forall a. List (Pattern + ListRestPattern) -> Cont a -> Cont a
 argPat Nil k = k
-argPat (Left p : pis) k = let apf = argPat pis k in ContElim (patternFwd p apf)
+argPat (Left p : pis) k = let apf = argPat pis k in ContElim (patternFwd2 p apf)
 argPat (Right o : pis) k = let apf = argPat pis k in ContElim (listRestPat o apf)
 
 listRestPat :: forall a. ListRestPattern -> Cont a -> Elim a
@@ -146,7 +146,7 @@ listRestPat (PNext p o) k = ElimConstr (D.singleton cCons (argPat (Left p : Righ
 
 recordPat :: forall a. List (Bind Pattern) -> Cont a -> Cont a
 recordPat Nil k = k
-recordPat (_ ↦ p : _) k = ContElim (patternFwd p k)
+recordPat (_ ↦ p : _) k = ContElim (patternFwd2 p k)
 
 -- Totalize equivalents
 totalCont :: forall a. Cont a -> a -> Cont a
@@ -235,3 +235,148 @@ instance JoinSemilattice a => JoinSemilattice (SExpr a) where
    let term2 = desug term = E.Constr cCons (1 : Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))
    eval term2 = V.Constr cCons (1 : (eval (Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))))
 -}
+
+
+enil :: forall a. a -> E.Expr a
+enil α = E.Constr α cNil Nil
+
+econs :: forall a. a -> E.Expr a -> E.Expr a -> E.Expr a
+econs α e e' = E.Constr α cCons (e : e' : Nil)
+
+elimBool :: forall a. Cont a -> Cont a -> Elim a
+elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
+
+
+
+
+-- Surface language supports "blocks" of variable declarations; core does not.
+moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
+moduleFwd (Module ds) = 
+   E.Module <$> traverse varDefOrRecDefsFwd (P.join (desugarDefs <$> ds))
+   where
+   varDefOrRecDefsFwd :: (VarDef a + RecDefs a) -> MayFail (E.VarDef a + E.RecDefs a)
+   varDefOrRecDefsFwd (Left d) = Left <$> varDefFwd d
+   varDefOrRecDefsFwd (Right xcs) = Right <$> recDefsFwd xcs
+
+   desugarDefs :: (VarDefs a + RecDefs a) -> List (VarDef a + RecDefs a)
+   desugarDefs (Left ds') = Left <$> toList ds'
+   desugarDefs (Right δ) = pure (Right δ)
+
+
+
+
+varDefFwd :: forall a. JoinSemilattice a => VarDef a -> MayFail (E.VarDef a)
+varDefFwd (VarDef π s) = E.VarDef <$> patternFwd π (ContNone :: Cont a) <*> pure s
+
+varDefsFwd :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> MayFail (E.Expr a)
+varDefsFwd (NonEmptyList (d :| Nil) × s) =
+   E.Let <$> varDefFwd d <*> pure s
+varDefsFwd (NonEmptyList (d :| d' : ds) × s) =
+   E.Let <$> varDefFwd d <*> varDefsFwd (NonEmptyList (d' :| ds) × s)
+
+-- In the formalism, "group by name" is part of the syntax.
+-- cs desugar_fwd σ
+recDefsFwd :: forall a. JoinSemilattice a => RecDefs a -> MayFail (E.RecDefs a)
+recDefsFwd xcs = D.fromFoldable <$> traverse recDefFwd xcss
+   where
+   xcss = groupBy (eq `on` fst) xcs :: NonEmptyList (NonEmptyList (Clause a))
+
+recDefFwd :: forall a. JoinSemilattice a => NonEmptyList (Clause a) -> MayFail (Bind (Elim a))
+recDefFwd xcs = (fst (head xcs) ↦ _) <$> branchesFwd_curried (snd <$> xcs)
+
+-- s desugar_fwd e
+exprFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
+exprFwd (BinaryApp s1 op s2) = pure (E.App (E.App (E.Op op) s1) s2)
+exprFwd (MatchAs s bs) = E.App <$> (E.Lambda <$> branchesFwd_uncurried bs) <*> pure s
+exprFwd (IfElse s1 s2 s3) = 
+   E.App (E.Lambda (elimBool (ContExpr s2) (ContExpr s3))) <$> pure s1
+exprFwd (ListEmpty α) = pure (enil α)
+exprFwd (ListNonEmpty α s l) = pure (econs α s (thunkSugar l))
+exprFwd (ListEnum s1 s2) = E.App <$> ((E.App (E.Var "enumFromTo")) <$> pure s1) <*> pure s2
+-- | List-comp-done
+exprFwd (ListComp _ s_body (NonEmptyList (Guard (E.Constr α2 c Nil) :| Nil))) | c == cTrue =
+   pure (econs α2 s_body (enil α2))
+-- | List-comp-last
+exprFwd (ListComp α s_body (NonEmptyList (q :| Nil))) =
+   pure $ thunkSugar (ListComp α s_body (NonEmptyList (q :| Guard (E.Constr α cTrue Nil) : Nil)))
+-- | List-comp-guard
+exprFwd (ListComp α s_body (NonEmptyList (Guard s :| q : qs))) = do
+   let e = thunkSugar (ListComp α s_body (NonEmptyList (q :| qs)))
+   E.App (E.Lambda (elimBool (ContExpr e) (ContExpr (enil α)))) <$> pure s
+-- | List-comp-decl
+exprFwd (ListComp α s_body (NonEmptyList (Declaration (VarDef π s) :| q : qs))) = do
+   let e = thunkSugar (ListComp α s_body (NonEmptyList (q :| qs)))
+   σ <- patternFwd π (ContExpr e :: Cont a)
+   E.App (E.Lambda σ) <$> pure s
+-- | List-comp-gen
+exprFwd (ListComp α s_body (NonEmptyList (Generator p s :| q : qs))) = do
+   let e = thunkSugar (ListComp α s_body (NonEmptyList (q :| qs)))
+   σ <- patternFwd p (ContExpr e)
+   E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totaliseFwd (ContElim σ) α)))) <$> pure s
+exprFwd (Let ds s) = varDefsFwd (ds × s)
+exprFwd (LetRec xcs s) = E.LetRec <$> recDefsFwd xcs <*> pure s
+
+-- l desugar_fwd e
+listRestFwd :: forall a. JoinSemilattice a => ListRest a -> MayFail (E.Expr a)
+listRestFwd (End α) = pure (enil α)
+listRestFwd (Next α s l) = pure (econs α s (thunkSugar l))
+
+-- ps, e desugar_fwd σ
+patternsFwd :: forall a. JoinSemilattice a => NonEmptyList Pattern × E.Expr a -> MayFail (Elim a)
+patternsFwd (NonEmptyList (p :| Nil) × e) = branchFwd_uncurried p e
+patternsFwd (NonEmptyList (p :| p' : ps) × e) =
+   patternFwd p =<< ContExpr <$> E.Lambda <$> patternsFwd (NonEmptyList (p' :| ps) × e)
+
+patternFwd :: forall a. Pattern -> Cont a -> MayFail (Elim a)
+patternFwd (PVar x) κ = pure (ElimVar x κ)
+patternFwd (PConstr c ps) κ =
+   checkArity c (length ps) *> (ElimConstr <$> D.singleton c <$> argPatternFwd (Left <$> ps) κ)
+patternFwd (PRecord xps) κ = ElimRecord (keys xps) <$> recordPatternFwd (sortBy (flip compare `on` fst) xps) κ
+patternFwd PListEmpty κ = pure (ElimConstr (D.singleton cNil κ))
+patternFwd (PListNonEmpty p o) κ = ElimConstr <$> D.singleton cCons <$> argPatternFwd (Left p : Right o : Nil) κ
+
+-- o, κ desugar_fwd σ
+listRestPatternFwd :: forall a. ListRestPattern -> Cont a -> MayFail (Elim a)
+listRestPatternFwd PEnd κ = pure (ElimConstr (D.singleton cNil κ))
+listRestPatternFwd (PNext p o) κ = ElimConstr <$> D.singleton cCons <$> argPatternFwd (Left p : Right o : Nil) κ
+
+argPatternFwd :: forall a. List (Pattern + ListRestPattern) -> Cont a -> MayFail (Cont a)
+argPatternFwd Nil κ = pure κ
+argPatternFwd (Left p : πs) κ = ContElim <$> (argPatternFwd πs κ >>= patternFwd p)
+argPatternFwd (Right o : πs) κ = ContElim <$> (argPatternFwd πs κ >>= listRestPatternFwd o)
+
+recordPatternFwd :: forall a. List (Bind Pattern) -> Cont a -> MayFail (Cont a)
+recordPatternFwd Nil κ = pure κ
+recordPatternFwd (_ ↦ p : xps) κ = patternFwd p κ >>= ContElim >>> recordPatternFwd xps
+
+branchFwd_uncurried :: forall a. JoinSemilattice a => Pattern -> E.Expr a -> MayFail (Elim a)
+branchFwd_uncurried p s = let cont = ContExpr s in patternFwd p cont
+
+branchesFwd_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> MayFail (Elim a)
+branchesFwd_curried bs = do
+   NonEmptyList (σ :| σs) <- traverse patternsFwd bs
+   foldM maybeJoin σ σs
+
+branchesFwd_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × E.Expr a) -> MayFail (Elim a)
+branchesFwd_uncurried bs = do
+   NonEmptyList (σ :| σs) <- traverse (uncurry branchFwd_uncurried) bs
+   foldM maybeJoin σ σs
+
+totaliseFwd :: forall a. Cont a -> a -> Cont a
+totaliseFwd ContNone _ = error absurd
+totaliseFwd (ContExpr e) _ = ContExpr e
+totaliseFwd (ContElim (ElimConstr m)) α = ContElim (ElimConstr (totaliseConstrFwd (c × totaliseFwd κ α) α))
+   where
+   c × κ = asSingletonMap m
+totaliseFwd (ContElim (ElimRecord xs κ)) α = ContElim (ElimRecord xs (totaliseFwd κ α))
+totaliseFwd (ContElim (ElimVar x κ)) α = ContElim (ElimVar x (totaliseFwd κ α))
+
+-- Extend singleton branch to set of branches where any missing constructors have been mapped to the empty list,
+-- using anonymous variables in any generated patterns.
+totaliseConstrFwd :: forall a. Ctr × Cont a -> a -> Dict (Cont a)
+totaliseConstrFwd (c × κ) α =
+   let
+      defaultBranch c' = c' × applyN (ContElim <<< ElimVar varAnon) (successful (arity c')) (ContExpr (enil α))
+      cκs = defaultBranch <$> ((ctrs (successful (dataTypeFor c)) # S.toUnfoldable) \\ L.singleton c)
+   in
+      D.fromFoldable ((c × κ) : cκs)

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -14,7 +14,7 @@ import Data.Set (toUnfoldable) as S
 import Data.Traversable (traverse)
 import Data.Tuple (fst, snd, uncurry)
 import DataType (Ctr, arity, cCons, cFalse, cNil, cTrue, checkArity, ctrs, dataTypeFor)
-import Dict (asSingletonMap, Dict(..))
+import Dict (asSingletonMap, Dict)
 import Dict as D
 import Expr2 (class Desugarable, class Desugarable2, Cont(..), Elim(..), Expr, asElim, desug, thunkSugar)
 import Expr2 (Expr(..), RecDefs, VarDef(..), Module(..)) as E
@@ -251,7 +251,7 @@ elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
 
 -- Surface language supports "blocks" of variable declarations; core does not.
 moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
-moduleFwd (Module ds) = 
+moduleFwd (Module ds) =
    E.Module <$> traverse varDefOrRecDefsFwd (P.join (desugarDefs <$> ds))
    where
    varDefOrRecDefsFwd :: (VarDef a + RecDefs a) -> MayFail (E.VarDef a + E.RecDefs a)
@@ -288,7 +288,7 @@ recDefFwd xcs = (fst (head xcs) ↦ _) <$> branchesFwd_curried (snd <$> xcs)
 exprFwd :: forall a. JoinSemilattice a => SExpr a -> MayFail (E.Expr a)
 exprFwd (BinaryApp s1 op s2) = pure (E.App (E.App (E.Op op) s1) s2)
 exprFwd (MatchAs s bs) = E.App <$> (E.Lambda <$> branchesFwd_uncurried bs) <*> pure s
-exprFwd (IfElse s1 s2 s3) = 
+exprFwd (IfElse s1 s2 s3) =
    E.App (E.Lambda (elimBool (ContExpr s2) (ContExpr s3))) <$> pure s1
 exprFwd (ListEmpty α) = pure (enil α)
 exprFwd (ListNonEmpty α s l) = pure (econs α s (E.Sugar (thunkSugar l)))

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -11,9 +11,8 @@ import Data.List (singleton) as L
 import Data.List.NonEmpty (NonEmptyList(..), groupBy, head)
 import Data.NonEmpty ((:|))
 import Data.Set (toUnfoldable) as S
-import Data.Traversable (traverse)
-import Data.Tuple (fst, snd, uncurry)
-import DataType (Ctr, arity, checkArity, cCons, cFalse, cNil, cTrue, ctrs, dataTypeFor)
+import Data.Tuple (fst, snd)
+import DataType (Ctr, arity, cCons, cFalse, cNil, cTrue, ctrs, dataTypeFor)
 import Dict (asSingletonMap)
 import Dict as D
 import Expr2 (Expr(..), RecDefs, VarDef(..)) as E
@@ -34,13 +33,18 @@ instance JoinSemilattice a => Desugarable SExpr a where
     -- Correct
     desug (BinaryApp l op r)           = E.App (E.App (E.Op op) l) r 
     -- Correct dependent on "clauses" which is meant to be equivalent to branchesFwd_uncurried
-    desug (MatchAs guard patterns)     = E.App (E.Lambda (clauses patterns)) guard 
+    desug (MatchAs guard patterns)     = E.App (E.Lambda (branchesFwd_uncurried patterns)) guard 
     -- Correct
     desug (IfElse guard trueP falseP)  = E.App (E.Lambda (elimBool (ContExpr trueP) (ContExpr falseP))) guard
     -- Correct                                             
     desug (ListEmpty ann)              = E.Constr ann cNil Nil
+
+
     -- Needs to be checked but either this is correct or, we need mkSugar in parsing
     desug (ListNonEmpty ann head rest) = scons ann head (mkSugar rest)
+    
+    
+    
     -- Correct
     desug (ListEnum head last)         = E.App (E.App (E.Var "enumFromTo") head) last
     desug (ListComp _ body (NonEmptyList (Guard (E.Constr ann2 c Nil) :| Nil))) | c == cTrue = 
@@ -56,33 +60,44 @@ instance JoinSemilattice a => Desugarable SExpr a where
     desug (ListComp ann body (NonEmptyList (Declaration (VarDef pi s) :| q : qs))) = 
         let 
             e   = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-            sig = desugPWithC pi (ContExpr e :: Cont a)
+            sig = patternFwd pi (ContExpr e :: Cont a)
         in
         E.App (E.Lambda sig) (mkSugar s)
     -- Need to check mkSugars
     desug (ListComp ann body (NonEmptyList (Generator p s :| q : qs))) = 
         let 
             e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-            sig = desugPWithC p (ContExpr e)
+            sig = patternFwd p (ContExpr e)
         in
         E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totalCont (ContElim sig) ann)))) s
     -- these 2 are correct if their auxiliaries are correct
     desug (Let defs exp)               = processVarDefs (defs × exp)
     desug (LetRec recdefs exp)         = E.LetRec (processRecDefs recdefs) exp
 
+
+
+
 -- ListRest auxiliaries
 instance JoinSemilattice a => Desugarable ListRest a where
     desug (End ann) = E.Constr ann cNil Nil
-    desug (Next ann head rest) = scons ann (desug head) (mkSugar rest)
+    desug (Next ann head rest) = scons ann head (mkSugar rest)
+
+
+
+
+
 
 -- vardefsFwd equivalent
 processVarDefs :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> E.Expr a
 processVarDefs (NonEmptyList (d :| Nil) × exp) = E.Let (processVarDef d) (mkSugar exp)
 processVarDefs (NonEmptyList (d :| d' : ds) × exp) = 
     E.Let (processVarDef d) (processVarDefs (NonEmptyList (d' :| ds) × exp))
+
+
 --vardefFwd equivalent
 processVarDef :: forall a. JoinSemilattice a => VarDef a -> E.VarDef a
-processVarDef (VarDef pat exp) = E.VarDef (desugPWithC pat (ContNone :: Cont a)) (mkSugar exp)
+processVarDef (VarDef pat exp) = E.VarDef (patternFwd pat (ContNone :: Cont a)) (mkSugar exp)
+
 -- recdefsFwd equivalent
 processRecDefs :: forall a. JoinSemilattice a => RecDefs a -> E.RecDefs a
 processRecDefs cls = D.fromFoldable $ map processRecDef clss
@@ -92,39 +107,40 @@ processRecDefs cls = D.fromFoldable $ map processRecDef clss
 processRecDef :: forall a. JoinSemilattice a => NonEmptyList (Clause a) -> Bind (Elim a)
 processRecDef x = 
     let pairer = (fst (head x) ↦ _)          :: forall b. b -> Bind b   
-        cls    =  clausesCurried (map snd x) :: Elim a
+        cls    =  branchesFwd_curried (map snd x) :: Elim a
     in 
         pairer cls
 
 -- clause functions equivalent to branches
-clause :: forall a. JoinSemilattice a => Pattern × Expr a -> Elim a
-clause (pat × exp) = let cont = ContExpr exp in desugPWithC pat cont
+branchFwd :: forall a. JoinSemilattice a => Pattern × Expr a -> Elim a
+branchFwd (pat × exp) = let cont = ContExpr exp in patternFwd pat cont
 
-clausesCurried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> Elim a
-clausesCurried cls = 
-            let NonEmptyList (head :| rest) = traverse desugPWithC cls in
+branchesFwd_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> Elim a
+branchesFwd_curried cls = 
+            let NonEmptyList (head :| rest) = map patternsFwd cls in
                 foldl join head rest
-clauses :: forall a. JoinSemilattice a => NonEmptyList (Pattern × Expr a) -> Elim a
-clauses cls = 
-            let NonEmptyList (head :| rest) = map clause cls in
+branchesFwd_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × Expr a) -> Elim a
+branchesFwd_uncurried cls = 
+            let NonEmptyList (head :| rest) = map branchFwd cls in
                 foldl join head rest
+
 -- these are equivalent to patternsFwd etc
-desugPWithC :: forall a. Pattern -> Cont a -> Elim a
-desugPWithC (PVar x)              k = ElimVar x k
-desugPWithC (PConstr c ps)        k = 
+patternFwd :: forall a. Pattern -> Cont a -> Elim a
+patternFwd (PVar x)              k = ElimVar x k
+patternFwd (PConstr c ps)        k = 
     ElimConstr ((D.singleton c) (argPat (map Left ps) k)) 
-desugPWithC (PRecord bps)         k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
-desugPWithC  PListEmpty           k = ElimConstr (D.singleton cNil k)
-desugPWithC (PListNonEmpty p lrp) k = ElimConstr (D.singleton cCons (argPat (Left p : Right lrp : Nil) k))
+patternFwd (PRecord bps)         k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
+patternFwd  PListEmpty           k = ElimConstr (D.singleton cNil k)
+patternFwd (PListNonEmpty p lrp) k = ElimConstr (D.singleton cCons (argPat (Left p : Right lrp : Nil) k))
 
-desugPsWithC :: forall a. JoinSemilattice a => NonEmptyList Pattern × Expr a -> Elim a
-desugPsWithC (NonEmptyList (p :| Nil) × exp)     = clause (p × exp)
-desugPsWithC (NonEmptyList (p :| p' : ps) × exp) = 
-    desugPWithC p (ContExpr (E.Lambda (desugPsWithC (NonEmptyList (p' :| ps) × exp))))
+patternsFwd :: forall a. JoinSemilattice a => NonEmptyList Pattern × Expr a -> Elim a
+patternsFwd (NonEmptyList (p :| Nil) × exp)     = branchFwd (p × exp)
+patternsFwd (NonEmptyList (p :| p' : ps) × exp) = 
+    patternFwd p (ContExpr (E.Lambda (patternsFwd (NonEmptyList (p' :| ps) × exp))))
 
 argPat :: forall a. List (Pattern + ListRestPattern) -> Cont a -> Cont a
 argPat Nil k = k
-argPat (Left p : pis) k = let apf = argPat pis k   in ContElim (desugPWithC p apf)
+argPat (Left p : pis) k = let apf = argPat pis k   in ContElim (patternFwd p apf)
 argPat (Right o: pis) k = let apf = argPat pis k in ContElim (listRestPat o apf)
 
 listRestPat :: forall a. ListRestPattern -> Cont a -> Elim a
@@ -133,7 +149,7 @@ listRestPat (PNext p o) k = ElimConstr (D.singleton cCons (argPat (Left p : Righ
 
 recordPat :: forall a. List (Bind Pattern) -> Cont a -> Cont a
 recordPat Nil k = k
-recordPat (_ ↦ p : xps) k = ContElim (desugPWithC p k)
+recordPat (_ ↦ p : xps) k = ContElim (patternFwd p k)
 
 -- Totalize equivalents
 totalCont :: forall a. Cont a -> a -> Cont a
@@ -166,7 +182,7 @@ data SExpr a
 
 data ListRest a
    = End a
-   | Next a (SExpr a) (ListRest a)
+   | Next a (Expr a) (ListRest a)
 
 data Pattern
    = PVar Var
@@ -180,13 +196,13 @@ data ListRestPattern
    | PNext Pattern ListRestPattern
 
 -- in the spec, "clause" doesn't include the function name
-type Branch a = NonEmptyList Pattern × SExpr a
+type Branch a = NonEmptyList Pattern × Expr a
 type Clause a = Var × Branch a
 type RecDefs a = NonEmptyList (Clause a)
 
 -- The pattern/expr relationship is different to the one in branch (the expr is the "argument", not the "body").
 -- Using a data type makes for easier overloading.
-data VarDef a = VarDef Pattern (SExpr a)
+data VarDef a = VarDef Pattern (Expr a)
 type VarDefs a = NonEmptyList (VarDef a)
 
 data Qualifier a
@@ -215,3 +231,11 @@ instance JoinSemilattice a => JoinSemilattice (SExpr a) where
    join s = definedJoin s
    maybeJoin _ = error unimplemented
    neg = (<$>) neg
+
+
+
+{-
+    let term = parse "[1, 2, 3, 4]" = Sugar (S.ListNonEmpty (1) (LR.Next (2) (LR.Next (3) (LR.Next (4) (LR.End)))))
+    let term2 = desug term = E.Constr cCons (1 : Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))
+    eval term2 = V.Constr cCons (1 : (eval (Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))))
+ -}

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -62,7 +62,7 @@ instance JoinSemilattice a => Desugarable SExpr a where
             e   = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
             sig = patternFwd pi (ContExpr e :: Cont a)
         in
-        E.App (E.Lambda sig) (mkSugar s)
+        E.App (E.Lambda sig) s
     -- Need to check mkSugars
     desug (ListComp ann body (NonEmptyList (Generator p s :| q : qs))) = 
         let 
@@ -89,14 +89,14 @@ instance JoinSemilattice a => Desugarable ListRest a where
 
 -- vardefsFwd equivalent
 processVarDefs :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> E.Expr a
-processVarDefs (NonEmptyList (d :| Nil) × exp) = E.Let (processVarDef d) (mkSugar exp)
+processVarDefs (NonEmptyList (d :| Nil) × exp) = E.Let (processVarDef d) exp
 processVarDefs (NonEmptyList (d :| d' : ds) × exp) = 
     E.Let (processVarDef d) (processVarDefs (NonEmptyList (d' :| ds) × exp))
 
 
 --vardefFwd equivalent
 processVarDef :: forall a. JoinSemilattice a => VarDef a -> E.VarDef a
-processVarDef (VarDef pat exp) = E.VarDef (patternFwd pat (ContNone :: Cont a)) (mkSugar exp)
+processVarDef (VarDef pat exp) = E.VarDef (patternFwd pat (ContNone :: Cont a)) exp
 
 -- recdefsFwd equivalent
 processRecDefs :: forall a. JoinSemilattice a => RecDefs a -> E.RecDefs a
@@ -149,7 +149,7 @@ listRestPat (PNext p o) k = ElimConstr (D.singleton cCons (argPat (Left p : Righ
 
 recordPat :: forall a. List (Bind Pattern) -> Cont a -> Cont a
 recordPat Nil k = k
-recordPat (_ ↦ p : xps) k = ContElim (patternFwd p k)
+recordPat (_ ↦ p : xps) k = ContElim (patternFwd p k) -- todo
 
 -- Totalize equivalents
 totalCont :: forall a. Cont a -> a -> Cont a

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -15,7 +15,7 @@ import DataType (Ctr, arity, cCons, cFalse, cNil, cTrue, ctrs, dataTypeFor)
 import Dict (asSingletonMap)
 import Dict as D
 import Expr2 (Expr(..), RecDefs, VarDef(..)) as E
-import Expr2 (class Desugarable, Cont(..), Elim(..), Expr, asElim, desug, mkSugar)
+import Expr2 (class Desugarable, class Desugarable2, Cont(..), Elim(..), Expr, asElim, desug, mkSugar)
 import Lattice2 (class JoinSemilattice, definedJoin, join, neg)
 import Util (type (×), (×), type (+), absurd, error, unimplemented, successful)
 
@@ -27,7 +27,8 @@ snil ann = E.Constr ann cNil Nil
 
 elimBool :: forall a'. Cont a' -> Cont a' -> Elim a'
 elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
-
+-- instance Desugarable2 SExpr where
+--     desug2 = exprFwd
 instance Desugarable SExpr where
    -- Correct
    desug (BinaryApp l op r) = E.App (E.App (E.Op op) l) r

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -1,0 +1,93 @@
+module SExpr2 where
+
+import Prelude
+
+import Bindings (Bind, Var)
+import Data.Either (Either(..))
+import Data.List (List)
+import Data.List.NonEmpty (NonEmptyList)
+import DataType (Ctr)
+import Expr2 (class Desugarable, Expr)
+import Lattice (class JoinSemilattice, definedJoin, neg)
+import Util (type (×), (×), type (+), error, unimplemented)
+import Util.Pair (Pair)
+
+
+instance Desugarable SExpr a where
+    desug _ = error "todo"
+
+-- Surface language expressions.
+data SExpr a
+   = Var Var
+   | Op Var
+   | Int a Int
+   | Float a Number
+   | Str a String
+   | Constr a Ctr (List (Expr a))
+   | Record a (List (Bind (Expr a)))
+   | Dictionary a (List (Pair (Expr a)))
+   | Matrix a (Expr a) (Var × Var) (Expr a)
+   | Lambda (NonEmptyList (Branch a))
+   | Project (Expr a) Var
+   | App (Expr a) (Expr a)
+   | BinaryApp (Expr a) Var (Expr a)
+   | MatchAs (Expr a) (NonEmptyList (Pattern × Expr a))
+   | IfElse (Expr a) (Expr a) (Expr a)
+   | ListEmpty a -- called [] in the paper
+   | ListNonEmpty a (Expr a) (ListRest a)
+   | ListEnum (Expr a) (Expr a)
+   | ListComp a (Expr a) (NonEmptyList (Qualifier a))
+   | Let (VarDefs a) (Expr a)
+   | LetRec (RecDefs a) (Expr a)
+
+data ListRest a
+   = End a
+   | Next a (SExpr a) (ListRest a)
+
+data Pattern
+   = PVar Var
+   | PConstr Ctr (List Pattern)
+   | PRecord (List (Bind Pattern))
+   | PListEmpty
+   | PListNonEmpty Pattern ListRestPattern
+
+data ListRestPattern
+   = PEnd
+   | PNext Pattern ListRestPattern
+
+-- in the spec, "clause" doesn't include the function name
+type Branch a = NonEmptyList Pattern × SExpr a
+type Clause a = Var × Branch a
+type RecDefs a = NonEmptyList (Clause a)
+
+-- The pattern/expr relationship is different to the one in branch (the expr is the "argument", not the "body").
+-- Using a data type makes for easier overloading.
+data VarDef a = VarDef Pattern (SExpr a)
+type VarDefs a = NonEmptyList (VarDef a)
+
+data Qualifier a
+   = Guard (SExpr a)
+   | Generator Pattern (SExpr a)
+   | Declaration (VarDef a) -- could allow VarDefs instead
+
+data Module a = Module (List (VarDefs a + RecDefs a))
+
+-- ======================
+-- boilerplate
+-- ======================
+derive instance Functor SExpr
+derive instance Functor ListRest
+derive instance Functor VarDef
+derive instance Functor Qualifier
+
+instance Functor Module where
+   map f (Module defs) = Module (mapDefs f <$> defs)
+      where
+      mapDefs :: forall a b. (a -> b) -> VarDefs a + RecDefs a -> VarDefs b + RecDefs b
+      mapDefs g (Left ds) = Left $ map g <$> ds
+      mapDefs g (Right ds) = Right $ (\(x × (ps × s)) -> x × (ps × (g <$> s))) <$> ds
+
+instance JoinSemilattice a => JoinSemilattice (SExpr a) where
+   join s = definedJoin s
+   maybeJoin _ = error unimplemented
+   neg = (<$>) neg

--- a/src/SExpr2.purs
+++ b/src/SExpr2.purs
@@ -29,69 +29,59 @@ elimBool :: forall a'. Cont a' -> Cont a' -> Elim a'
 elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
 
 instance Desugarable SExpr where
-    -- Correct
-    desug (BinaryApp l op r)           = E.App (E.App (E.Op op) l) r
-    -- Correct dependent on "clauses" which is meant to be equivalent to branchesFwd_uncurried
-    desug (MatchAs guard patterns)     = E.App (E.Lambda (branchesFwd_uncurried patterns)) guard
-    -- Correct
-    desug (IfElse guard trueP falseP)  = E.App (E.Lambda (elimBool (ContExpr trueP) (ContExpr falseP))) guard
-    -- Correct
-    desug (ListEmpty ann)              = E.Constr ann cNil Nil
+   -- Correct
+   desug (BinaryApp l op r) = E.App (E.App (E.Op op) l) r
+   -- Correct dependent on "clauses" which is meant to be equivalent to branchesFwd_uncurried
+   desug (MatchAs guard patterns) = E.App (E.Lambda (branchesFwd_uncurried patterns)) guard
+   -- Correct
+   desug (IfElse guard trueP falseP) = E.App (E.Lambda (elimBool (ContExpr trueP) (ContExpr falseP))) guard
+   -- Correct
+   desug (ListEmpty ann) = E.Constr ann cNil Nil
 
+   -- Needs to be checked but either this is correct or, we need mkSugar in parsing
+   desug (ListNonEmpty ann head rest) = scons ann head (mkSugar rest)
 
-    -- Needs to be checked but either this is correct or, we need mkSugar in parsing
-    desug (ListNonEmpty ann head rest) = scons ann head (mkSugar rest)
-
-
-
-    -- Correct
-    desug (ListEnum head last)         = E.App (E.App (E.Var "enumFromTo") head) last
-    desug (ListComp _ body (NonEmptyList (Guard (E.Constr ann2 c Nil) :| Nil))) | c == cTrue =
-        scons ann2 body (snil ann2) -- Should be correct
-    -- Need to check this one
-    desug (ListComp ann body (NonEmptyList (q :| Nil))) =
-        desug (ListComp ann body (NonEmptyList  (q :| Guard (E.Constr ann cTrue Nil) : Nil))) -- may need to be mkSugar
-    -- Need to check
-    desug (ListComp ann body (NonEmptyList (Guard s :| q : qs))) =
-        let e = mkSugar (ListComp ann body (NonEmptyList (q :| qs))) in
-        E.App (E.Lambda (elimBool (ContExpr e) (ContExpr (snil ann)))) s
-    -- Need to check the mkSugar's here
-    desug (ListComp ann body (NonEmptyList (Declaration (VarDef pi s) :| q : qs))) =
-        let
-            e   = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-            sig = patternFwd pi (ContExpr e :: Cont _)
-        in
-        E.App (E.Lambda sig) s
-    -- Need to check mkSugars
-    desug (ListComp ann body (NonEmptyList (Generator p s :| q : qs))) =
-        let
-            e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
-            sig = patternFwd p (ContExpr e)
-        in
-        E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totalCont (ContElim sig) ann)))) s
-    -- these 2 are correct if their auxiliaries are correct
-    desug (Let defs exp)               = processVarDefs (defs × exp)
-    desug (LetRec recdefs exp)         = E.LetRec (processRecDefs recdefs) exp
-
-
-
+   -- Correct
+   desug (ListEnum head last) = E.App (E.App (E.Var "enumFromTo") head) last
+   desug (ListComp _ body (NonEmptyList (Guard (E.Constr ann2 c Nil) :| Nil))) | c == cTrue =
+      scons ann2 body (snil ann2) -- Should be correct
+   -- Need to check this one
+   desug (ListComp ann body (NonEmptyList (q :| Nil))) =
+      desug (ListComp ann body (NonEmptyList (q :| Guard (E.Constr ann cTrue Nil) : Nil))) -- may need to be mkSugar
+   -- Need to check
+   desug (ListComp ann body (NonEmptyList (Guard s :| q : qs))) =
+      let
+         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+      in
+         E.App (E.Lambda (elimBool (ContExpr e) (ContExpr (snil ann)))) s
+   -- Need to check the mkSugar's here
+   desug (ListComp ann body (NonEmptyList (Declaration (VarDef pi s) :| q : qs))) =
+      let
+         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+         sig = patternFwd pi (ContExpr e :: Cont _)
+      in
+         E.App (E.Lambda sig) s
+   -- Need to check mkSugars
+   desug (ListComp ann body (NonEmptyList (Generator p s :| q : qs))) =
+      let
+         e = mkSugar (ListComp ann body (NonEmptyList (q :| qs)))
+         sig = patternFwd p (ContExpr e)
+      in
+         E.App (E.App (E.Var "concatMap") (E.Lambda (asElim (totalCont (ContElim sig) ann)))) s
+   -- these 2 are correct if their auxiliaries are correct
+   desug (Let defs exp) = processVarDefs (defs × exp)
+   desug (LetRec recdefs exp) = E.LetRec (processRecDefs recdefs) exp
 
 -- ListRest auxiliaries
 instance Desugarable ListRest where
-    desug (End ann) = E.Constr ann cNil Nil
-    desug (Next ann head rest) = scons ann head (mkSugar rest)
-
-
-
-
-
+   desug (End ann) = E.Constr ann cNil Nil
+   desug (Next ann head rest) = scons ann head (mkSugar rest)
 
 -- vardefsFwd equivalent
 processVarDefs :: forall a. JoinSemilattice a => VarDefs a × E.Expr a -> E.Expr a
 processVarDefs (NonEmptyList (d :| Nil) × exp) = E.Let (processVarDef d) exp
 processVarDefs (NonEmptyList (d :| d' : ds) × exp) =
-    E.Let (processVarDef d) (processVarDefs (NonEmptyList (d' :| ds) × exp))
-
+   E.Let (processVarDef d) (processVarDefs (NonEmptyList (d' :| ds) × exp))
 
 --vardefFwd equivalent
 processVarDef :: forall a. JoinSemilattice a => VarDef a -> E.VarDef a
@@ -100,15 +90,17 @@ processVarDef (VarDef pat exp) = E.VarDef (patternFwd pat (ContNone :: Cont a)) 
 -- recdefsFwd equivalent
 processRecDefs :: forall a. JoinSemilattice a => RecDefs a -> E.RecDefs a
 processRecDefs cls = D.fromFoldable $ map processRecDef clss
-    where
-    clss = groupBy (eq `on` fst) cls :: NonEmptyList (NonEmptyList (Clause a))
+   where
+   clss = groupBy (eq `on` fst) cls :: NonEmptyList (NonEmptyList (Clause a))
+
 -- recdefFwd equivalent
 processRecDef :: forall a. JoinSemilattice a => NonEmptyList (Clause a) -> Bind (Elim a)
 processRecDef x =
-    let pairer = (fst (head x) ↦ _)          :: forall b. b -> Bind b
-        cls    =  branchesFwd_curried (map snd x) :: Elim a
-    in
-        pairer cls
+   let
+      pairer = (fst (head x) ↦ _) :: forall b. b -> Bind b
+      cls = branchesFwd_curried (map snd x) :: Elim a
+   in
+      pairer cls
 
 -- clause functions equivalent to branches
 branchFwd :: forall a. JoinSemilattice a => Pattern × Expr a -> Elim a
@@ -116,31 +108,36 @@ branchFwd (pat × exp) = let cont = ContExpr exp in patternFwd pat cont
 
 branchesFwd_curried :: forall a. JoinSemilattice a => NonEmptyList (Branch a) -> Elim a
 branchesFwd_curried cls =
-            let NonEmptyList (head :| rest) = map patternsFwd cls in
-                foldl join head rest
+   let
+      NonEmptyList (head :| rest) = map patternsFwd cls
+   in
+      foldl join head rest
+
 branchesFwd_uncurried :: forall a. JoinSemilattice a => NonEmptyList (Pattern × Expr a) -> Elim a
 branchesFwd_uncurried cls =
-            let NonEmptyList (head :| rest) = map branchFwd cls in
-                foldl join head rest
+   let
+      NonEmptyList (head :| rest) = map branchFwd cls
+   in
+      foldl join head rest
 
 -- these are equivalent to patternsFwd etc
 patternFwd :: forall a. Pattern -> Cont a -> Elim a
-patternFwd (PVar x)              k = ElimVar x k
-patternFwd (PConstr c ps)        k =
-    ElimConstr ((D.singleton c) (argPat (map Left ps) k))
-patternFwd (PRecord bps)         k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
-patternFwd  PListEmpty           k = ElimConstr (D.singleton cNil k)
+patternFwd (PVar x) k = ElimVar x k
+patternFwd (PConstr c ps) k =
+   ElimConstr ((D.singleton c) (argPat (map Left ps) k))
+patternFwd (PRecord bps) k = ElimRecord (keys bps) (recordPat (sortBy (flip compare `on` fst) bps) k)
+patternFwd PListEmpty k = ElimConstr (D.singleton cNil k)
 patternFwd (PListNonEmpty p lrp) k = ElimConstr (D.singleton cCons (argPat (Left p : Right lrp : Nil) k))
 
 patternsFwd :: forall a. JoinSemilattice a => NonEmptyList Pattern × Expr a -> Elim a
-patternsFwd (NonEmptyList (p :| Nil) × exp)     = branchFwd (p × exp)
+patternsFwd (NonEmptyList (p :| Nil) × exp) = branchFwd (p × exp)
 patternsFwd (NonEmptyList (p :| p' : ps) × exp) =
-    patternFwd p (ContExpr (E.Lambda (patternsFwd (NonEmptyList (p' :| ps) × exp))))
+   patternFwd p (ContExpr (E.Lambda (patternsFwd (NonEmptyList (p' :| ps) × exp))))
 
 argPat :: forall a. List (Pattern + ListRestPattern) -> Cont a -> Cont a
 argPat Nil k = k
-argPat (Left p : pis) k = let apf = argPat pis k   in ContElim (patternFwd p apf)
-argPat (Right o: pis) k = let apf = argPat pis k in ContElim (listRestPat o apf)
+argPat (Left p : pis) k = let apf = argPat pis k in ContElim (patternFwd p apf)
+argPat (Right o : pis) k = let apf = argPat pis k in ContElim (listRestPat o apf)
 
 listRestPat :: forall a. ListRestPattern -> Cont a -> Elim a
 listRestPat PEnd k = ElimConstr (D.singleton cNil k)
@@ -155,18 +152,19 @@ totalCont :: forall a. Cont a -> a -> Cont a
 totalCont ContNone _ = error absurd
 totalCont (ContExpr e) _ = ContExpr e
 totalCont (ContElim (ElimConstr m)) ann = ContElim (ElimConstr (totalizeCtr (c × totalCont k ann) ann))
-                                        where
-                                          c × k = asSingletonMap m
+   where
+   c × k = asSingletonMap m
 totalCont (ContElim (ElimRecord xs k)) ann = ContElim (ElimRecord xs (totalCont k ann))
 totalCont (ContElim (ElimVar x k)) ann = ContElim (ElimVar x (totalCont k ann))
 
 totalizeCtr :: forall a. Ctr × Cont a -> a -> D.Dict (Cont a)
 totalizeCtr (c × k) ann =
-    let
-        defaultBranch c' = c' × applyN (ContElim <<< ElimVar varAnon) (successful (arity c')) (ContExpr (snil ann))
-        cks = map defaultBranch ((ctrs (successful (dataTypeFor c)) # S.toUnfoldable ) \\ L.singleton c)
-    in
-        D.fromFoldable ((c × k) : cks)
+   let
+      defaultBranch c' = c' × applyN (ContElim <<< ElimVar varAnon) (successful (arity c')) (ContExpr (snil ann))
+      cks = map defaultBranch ((ctrs (successful (dataTypeFor c)) # S.toUnfoldable) \\ L.singleton c)
+   in
+      D.fromFoldable ((c × k) : cks)
+
 -- Surface language expressions.
 data SExpr a
    = BinaryApp (Expr a) Var (Expr a)
@@ -231,10 +229,8 @@ instance JoinSemilattice a => JoinSemilattice (SExpr a) where
    maybeJoin _ = error unimplemented
    neg = (<$>) neg
 
-
-
 {-
-    let term = parse "[1, 2, 3, 4]" = Sugar (S.ListNonEmpty (1) (LR.Next (2) (LR.Next (3) (LR.Next (4) (LR.End)))))
-    let term2 = desug term = E.Constr cCons (1 : Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))
-    eval term2 = V.Constr cCons (1 : (eval (Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))))
- -}
+   let term = parse "[1, 2, 3, 4]" = Sugar (S.ListNonEmpty (1) (LR.Next (2) (LR.Next (3) (LR.Next (4) (LR.End)))))
+   let term2 = desug term = E.Constr cCons (1 : Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))
+   eval term2 = V.Constr cCons (1 : (eval (Sugar (LR.Next 2 (LR.Next 3 (LR.Next 4 LR.End))))))
+-}

--- a/src/Trace2.purs
+++ b/src/Trace2.purs
@@ -1,0 +1,51 @@
+module Trace2 where
+
+import Prelude
+
+import Bindings (Var)
+import Data.Exists (Exists)
+import Data.List (List)
+import Data.Maybe (Maybe)
+import Data.Set (Set, empty, singleton, unions)
+import DataType (Ctr)
+import Dict (Dict)
+import Expr2 (class BV, RecDefs, bv)
+import Lattice2 (Raw)
+import Util (type (×))
+import Val2 (Array2, ForeignOp', Val)
+
+data Trace
+   = Var Var
+   | Op Var
+   | Const
+   | Record (Dict Trace)
+   | Dictionary (List (String × Trace × Trace)) (Dict (Raw Val))
+   | Constr Ctr (List Trace)
+   | Matrix (Array2 Trace) (Var × Var) (Int × Int) Trace
+   | Project Trace Var
+   | App Trace Trace AppTrace
+   | Let VarDef Trace
+   | LetRec (Raw RecDefs) Trace
+
+data AppTrace
+   = AppClosure (Set Var) Match Trace
+   -- these two forms represent partial (unsaturated) applications
+   | AppForeign Int ForeignTrace -- record number of arguments
+   | AppConstr Ctr
+
+data ForeignTrace' t = ForeignTrace' (ForeignOp' t) (Maybe t)
+type ForeignTrace = Exists ForeignTrace'
+
+data VarDef = VarDef Match Trace
+
+data Match
+   = MatchVar Var (Raw Val)
+   | MatchVarAnon (Raw Val)
+   | MatchConstr Ctr (List Match)
+   | MatchRecord (Dict Match)
+
+instance BV Match where
+   bv (MatchVar x _) = singleton x
+   bv (MatchVarAnon _) = empty
+   bv (MatchConstr _ ws) = unions (bv <$> ws)
+   bv (MatchRecord xws) = unions (bv <$> xws)

--- a/src/Val2.purs
+++ b/src/Val2.purs
@@ -1,0 +1,171 @@
+module Val2 where
+
+import Prelude hiding (absurd, append)
+
+import Bindings (Var)
+import Control.Apply (lift2)
+import Data.Exists (Exists)
+import Data.List (List(..), (:))
+import Data.Bifunctor (bimap)
+import Data.Set (Set, empty, fromFoldable, intersection, member, singleton, toUnfoldable, union)
+import DataType (Ctr)
+import Dict (Dict, get)
+import Expr2 (Elim, RecDefs, fv)
+import Foreign.Object (filterKeys, lookup, unionWith)
+import Foreign.Object (keys) as O
+import Lattice2 (class BoundedJoinSemilattice, class BoundedLattice, class Expandable, class JoinSemilattice, Raw, (∨), definedJoin, expand, maybeJoin, neg)
+import Text.Pretty (Doc, beside, text)
+import Util (Endo, MayFail, type (×), (×), (≞), (≜), (!), error, orElse, report, unsafeUpdateAt)
+
+data Val a
+   = Int a Int
+   | Float a Number
+   | Str a String
+   | Constr a Ctr (List (Val a)) -- always saturated
+   | Record a (Dict (Val a)) -- always saturated
+   | Dictionary a (Dict (a × Val a))
+   | Matrix a (MatrixRep a)
+   | Fun (Fun a)
+
+data Fun a
+   = Closure a (Env a) (RecDefs a) (Elim a)
+   | Foreign ForeignOp (List (Val a)) -- never saturated
+   | PartialConstr a Ctr (List (Val a)) -- never saturated
+
+class (Highlightable a, BoundedLattice a) <= Ann a
+
+instance Ann Boolean
+instance Ann Unit
+
+-- similar to an isomorphism lens with complement t
+type OpFwd t = forall a. Ann a => List (Val a) -> MayFail (t × Val a)
+type OpBwd t = forall a. Ann a => t × Val a -> List (Val a)
+
+data ForeignOp' t = ForeignOp'
+   { arity :: Int
+   , op :: OpFwd t
+   , op_bwd :: OpBwd t
+   }
+
+type ForeignOp = Exists ForeignOp'
+
+-- Environments.
+type Env a = Dict (Val a)
+
+lookup' :: forall a. Var -> Dict a -> MayFail a
+lookup' x γ = lookup x γ # orElse ("variable " <> x <> " not found")
+
+-- Want a monoid instance but needs a newtype
+append :: forall a. Env a -> Endo (Env a)
+append = unionWith (const identity)
+
+infixl 5 append as <+>
+
+append_inv :: forall a. Set Var -> Env a -> Env a × Env a
+append_inv xs γ = filterKeys (_ `not <<< member` xs) γ × restrict γ xs
+
+restrict :: forall a. Dict a -> Set Var -> Dict a
+restrict γ xs = filterKeys (_ `member` xs) γ
+
+reaches :: forall a. RecDefs a -> Endo (Set Var)
+reaches ρ xs = go (toUnfoldable xs) empty
+   where
+   dom_ρ = fromFoldable $ O.keys ρ
+
+   go :: List Var -> Endo (Set Var)
+   go Nil acc = acc
+   go (x : xs') acc | x `member` acc = go xs' acc
+   go (x : xs') acc | otherwise =
+      go (toUnfoldable (fv σ `intersection` dom_ρ) <> xs')
+         (singleton x `union` acc)
+      where
+      σ = get x ρ
+
+for :: forall a. RecDefs a -> Elim a -> RecDefs a
+for ρ σ = ρ `restrict` reaches ρ (fv σ `intersection` (fromFoldable $ O.keys ρ))
+
+-- Matrices.
+type Array2 a = Array (Array a)
+type MatrixRep a = Array2 (Val a) × (Int × a) × (Int × a)
+
+updateMatrix :: forall a. Int -> Int -> Endo (Val a) -> Endo (MatrixRep a)
+updateMatrix i j δv (vss × h × w) =
+   vss' × h × w
+   where
+   vs_i = vss ! (i - 1)
+   v_j = vs_i ! (j - 1)
+   vss' = unsafeUpdateAt (i - 1) (unsafeUpdateAt (j - 1) (δv v_j) vs_i) vss
+
+class Highlightable a where
+   highlightIf :: a -> Endo Doc
+
+instance Highlightable Unit where
+   highlightIf _ = identity
+
+instance Highlightable Boolean where
+   highlightIf false = identity
+   highlightIf true = \doc -> text "_" `beside` doc `beside` text "_"
+
+-- ======================
+-- boilerplate
+-- ======================
+instance Functor Val where
+   map f (Int α n) = Int (f α) n
+   map f (Float α n) = Float (f α) n
+   map f (Str α s) = Str (f α) s
+   map f (Record α xvs) = Record (f α) (map f <$> xvs)
+   map f (Dictionary α svs) = Dictionary (f α) (bimap f (map f) <$> svs)
+   map f (Constr α c vs) = Constr (f α) c (map f <$> vs)
+   -- PureScript can't derive this case
+   map f (Matrix α (r × iα × jβ)) = Matrix (f α) ((map (map f) <$> r) × (f <$> iα) × (f <$> jβ))
+   map f (Fun φ) = Fun (f <$> φ)
+
+derive instance Functor Fun
+
+instance JoinSemilattice a => JoinSemilattice (Val a) where
+   maybeJoin (Int α n) (Int α' n') = Int (α ∨ α') <$> (n ≞ n')
+   maybeJoin (Float α n) (Float α' n') = Float (α ∨ α') <$> (n ≞ n')
+   maybeJoin (Str α s) (Str α' s') = Str (α ∨ α') <$> (s ≞ s')
+   maybeJoin (Record α xvs) (Record α' xvs') = Record (α ∨ α') <$> maybeJoin xvs xvs'
+   maybeJoin (Dictionary α svs) (Dictionary α' svs') = Dictionary (α ∨ α') <$> maybeJoin svs svs'
+   maybeJoin (Constr α c vs) (Constr α' c' us) = Constr (α ∨ α') <$> (c ≞ c') <*> maybeJoin vs us
+   maybeJoin (Matrix α (vss × (i × βi) × (j × βj))) (Matrix α' (vss' × (i' × βi') × (j' × βj'))) =
+      Matrix (α ∨ α') <$>
+         ( maybeJoin vss vss'
+              `lift2 (×)` (((_ × (βi ∨ βi')) <$> (i ≞ i')) `lift2 (×)` ((_ × (βj ∨ βj')) <$> (j ≞ j')))
+         )
+   maybeJoin (Fun φ) (Fun φ') = Fun <$> maybeJoin φ φ'
+   maybeJoin _ _ = report "Incompatible values"
+
+   join v = definedJoin v
+   neg = (<$>) neg
+
+instance JoinSemilattice a => JoinSemilattice (Fun a) where
+   maybeJoin (Closure α γ ρ σ) (Closure α' γ' ρ' σ') =
+      Closure (α ∨ α') <$> maybeJoin γ γ' <*> maybeJoin ρ ρ' <*> maybeJoin σ σ'
+   maybeJoin (Foreign φ vs) (Foreign _ vs') = Foreign φ <$> maybeJoin vs vs' -- TODO: require φ == φ'
+   maybeJoin (PartialConstr α c vs) (PartialConstr α' c' us) =
+      PartialConstr (α ∨ α') <$> (c ≞ c') <*> maybeJoin vs us
+   maybeJoin _ _ = report "Incompatible functions"
+
+   join v = definedJoin v
+   neg = (<$>) neg
+
+instance BoundedJoinSemilattice a => Expandable (Val a) (Raw Val) where
+   expand (Int α n) (Int _ n') = Int α (n ≜ n')
+   expand (Float α n) (Float _ n') = Float α (n ≜ n')
+   expand (Str α s) (Str _ s') = Str α (s ≜ s')
+   expand (Record α xvs) (Record _ xvs') = Record α (expand xvs xvs')
+   expand (Dictionary α svs) (Dictionary _ svs') = Dictionary α (expand svs svs')
+   expand (Constr α c vs) (Constr _ c' us) = Constr α (c ≜ c') (expand vs us)
+   expand (Matrix α (vss × (i × βi) × (j × βj))) (Matrix _ (vss' × (i' × _) × (j' × _))) =
+      Matrix α (expand vss vss' × ((i ≜ i') × βi) × ((j ≜ j') × βj))
+   expand (Fun φ) (Fun φ') = Fun (expand φ φ')
+   expand _ _ = error "Incompatible values"
+
+instance BoundedJoinSemilattice a => Expandable (Fun a) (Raw Fun) where
+   expand (Closure α γ ρ σ) (Closure _ γ' ρ' σ') =
+      Closure α (expand γ γ') (expand ρ ρ') (expand σ σ')
+   expand (Foreign φ vs) (Foreign _ vs') = Foreign φ (expand vs vs') -- TODO: require φ == φ'
+   expand (PartialConstr α c vs) (PartialConstr _ c' us) = PartialConstr α (c ≜ c') (expand vs us)
+   expand _ _ = error "Incompatible values"

--- a/src/Val2.purs
+++ b/src/Val2.purs
@@ -67,7 +67,7 @@ append_inv xs γ = filterKeys (_ `not <<< member` xs) γ × restrict γ xs
 restrict :: forall a. Dict a -> Set Var -> Dict a
 restrict γ xs = filterKeys (_ `member` xs) γ
 
-reaches :: forall a. RecDefs a -> Endo (Set Var)
+reaches :: forall a. JoinSemilattice a => RecDefs a -> Endo (Set Var)
 reaches ρ xs = go (toUnfoldable xs) empty
    where
    dom_ρ = fromFoldable $ O.keys ρ
@@ -81,7 +81,7 @@ reaches ρ xs = go (toUnfoldable xs) empty
       where
       σ = get x ρ
 
-for :: forall a. RecDefs a -> Elim a -> RecDefs a
+for :: forall a. JoinSemilattice a => RecDefs a -> Elim a -> RecDefs a
 for ρ σ = ρ `restrict` reaches ρ (fv σ `intersection` (fromFoldable $ O.keys ρ))
 
 -- Matrices.


### PR DESCRIPTION
`Expr2.purs` contains definition of Expressions which uses an existential type to hide the fact that `Sugar` nodes are parameterized by the type of syntactic sugar. Instead, we can package up anything which implements `Desugarable` and use those as `Sugar` nodes in our expression language. This has resulted in changes to `SExpr` (reflected in `SExpr2`) as we can now defer the desugaring of a piece of sugar until it is required for evaluation. These changes have bubbled through to every file which is marked `Filename2.purs`