### PR TITLE
WIP more Desugarable rollout and tidyup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-app-tests": "yarn clean-app-tests && spago build --purs-args '--strict --censor-codes=UserDefinedWarning' && purs-backend-es bundle-app --main Test.App.Main --to dist/app-tests/app.js",
     "app-tests": "karma start karma.conf.app-tests.js",
     "app-tests-browser": "karma start karma.conf.app-tests.js --browsers=Chrome --singleRun=false",
-    "tidy": "yarn purs-tidy format-in-place src/**/*.purs test/**/*.purs"
+    "tidy": "yarn purs-tidy format-in-place src/*.purs src/**/*.purs test/*.purs test/**/*.purs"
   },
   "dependencies": {
     "d3": "6.7.0",

--- a/src/Desugarable.purs
+++ b/src/Desugarable.purs
@@ -17,9 +17,13 @@ class FromSugar e where
    fromSug :: forall a. Sugar' e -> e a -> e a
    toSug :: forall a. e a -> Sugar' e × e a
 
-class (Functor s, Functor e, FromSugar e) <= Desugarable (s :: Type -> Type) (e :: Type -> Type) | s -> e where
+class (Functor s, Functor e, FromSugar e) <= Desugarable s e | s -> e where
    desugFwd :: forall a. JoinSemilattice a => s a -> MayFail (e a)
    desugBwd :: forall a. BoundedJoinSemilattice a => e a -> Raw s -> s a
+
+-- A similar pattern is where some auxiliary data of type p suffices to determine the bwd direction:
+-- desugFwd :: forall a. JoinSemilattice a => p -> s a -> MayFail (e a)
+-- desugBwd :: forall a. BoundedJoinSemilattice a => p -> e a -> s a
 
 desugFwd' :: forall s e a. JoinSemilattice a => Desugarable s e => s a -> MayFail (e a)
 desugFwd' s = fromSug (wrapSugar $ erase s) <$> desugFwd s

--- a/src/Eval.purs
+++ b/src/Eval.purs
@@ -159,9 +159,9 @@ eval γ (LetRec ρ e) α = do
    let γ' = closeDefs γ ρ α
    t × v <- eval (γ <+> γ') e α
    pure $ T.LetRec (erase <$> ρ) t × v
-eval γ sug@(Sugar _ e) α = do
+eval γ (Sugar s e) α = do
    (t × v) <- eval γ e α
-   let t' = T.Sugar (erase sug) t
+   let t' = T.Sugar s t
    pure (t' × v)
 
 eval_module :: forall a. Ann a => Env a -> Module a -> a -> MayFail (Env a)

--- a/src/EvalBwd.purs
+++ b/src/EvalBwd.purs
@@ -195,7 +195,7 @@ evalBwd' v (T.LetRec ρ t) =
    { γ: γ1γ2, e, α } = evalBwd' v t
    γ1 × γ2 = append_inv (S.fromFoldable $ keys ρ) γ1γ2
    γ1' × ρ' × α' = closeDefsBwd γ2
-evalBwd' v (T.Sugar (Sugar s _) t) = { γ: γ1, e: Sugar s e1, α: α1 }
+evalBwd' v (T.Sugar s t) = { γ, e: Sugar s e, α }
    where
-   { γ: γ1, e: e1, α: α1 } = evalBwd' v t
+   { γ, e, α } = evalBwd' v t
 evalBwd' _ _ = error absurd

--- a/src/Expr.purs
+++ b/src/Expr.purs
@@ -147,7 +147,7 @@ instance BoundedJoinSemilattice a => Expandable (Elim a) (Raw Elim) where
    expand (ElimVar x κ) (ElimVar x' κ') = ElimVar (x ≜ x') (expand κ κ')
    expand (ElimConstr cκs) (ElimConstr cκs') = ElimConstr (expand cκs cκs')
    expand (ElimRecord xs κ) (ElimRecord ys κ') = ElimRecord (xs ≜ ys) (expand κ κ')
-   expand (ElimSug _ _) (ElimSug _ _) = error "expanding sugar elims"
+   expand (ElimSug s e) (ElimSug _ e') = ElimSug s (expand e e')
    expand _ _ = error "Incompatible eliminators"
 
 instance JoinSemilattice a => JoinSemilattice (Cont a) where

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -26,7 +26,7 @@ import Parsing.String (char, eof)
 import Parsing.String.Basic (oneOf)
 import Parsing.Token (GenLanguageDef(..), LanguageDef, TokenParser, alphaNum, letter, makeTokenParser, unGenLanguageDef)
 import Primitive.Parse (OpDef, opDefs)
-import SExpr (Branch, Clause(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
+import SExpr (Branch, Clause(..), Clauses(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (Endo, type (×), (×), type (+), error, onlyIf)
 import Util.Pair (Pair(..))
 import Util.Parse (SParser, sepBy_try, sepBy1_try, some)
@@ -413,7 +413,7 @@ expr_ = fix $ appChain >>> buildExprParser ([ backtickOp ] `cons` operators bina
             (pure $ \e e' -> Constr unit cPair (e : e' : empty)) <*> (expr' <* token.comma) <*> expr'
 
          lambda :: SParser (Raw Expr)
-         lambda = Lambda <$> (keyword str.fun *> branches expr' clause_curried)
+         lambda = (Lambda <<< Clauses) <$> (keyword str.fun *> branches expr' clause_curried)
 
          ifElse :: SParser (Raw Expr)
          ifElse = pure IfElse

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -8,6 +8,7 @@ import Data.Foldable (class Foldable)
 import Data.List (List(..), (:), fromFoldable, null)
 import Data.List.NonEmpty (NonEmptyList)
 import Data.List.NonEmpty (toList) as NEL
+import Data.Newtype (unwrap)
 import Data.Profunctor.Choice ((|||))
 import Data.Profunctor.Strong (first)
 import Data.String (Pattern(..), contains) as Data.String
@@ -211,7 +212,7 @@ instance Highlightable a => Pretty (S.Expr a) where
       where
       init = [ text str.arrayLBracket, pretty e, text str.bar ]
       quant = [ parens (hcomma [ text x, text y ]), text (str.in_), pretty e', text str.arrayRBracket ]
-   pretty (S.Lambda bs) = hspace [ text str.fun, vert semi (pretty <$> bs) ]
+   pretty (S.Lambda bs) = hspace [ text str.fun, vert semi (pretty <$> unwrap bs) ]
    pretty (S.Project s x) = pretty s :<>: text (str.dot <> x)
    pretty (S.App s s') = hspace [ pretty s, pretty s' ]
    pretty (S.BinaryApp s op s') = parens (hspace [ pretty s, text op, pretty s' ])

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -17,9 +17,9 @@ import Data.Set (toUnfoldable) as S
 import Data.Traversable (traverse)
 import Data.Tuple (uncurry, fst, snd)
 import DataType (Ctr, arity, checkArity, ctrs, cCons, cFalse, cNil, cTrue, dataTypeFor)
+import Desugarable (class Desugarable, desugBwd', desugFwd')
 import Dict (Dict, asSingletonMap, get)
 import Dict (fromFoldable, singleton) as D
-import Desugarable (class Desugarable, desugFwd', desugBwd')
 import Expr (Cont(..), Elim(..), asElim, asExpr)
 import Expr (Expr(..), Module(..), RecDefs, VarDef(..)) as E
 import Lattice (class JoinSemilattice, (∨), bot, definedJoin, neg, maybeJoin, class BoundedJoinSemilattice, Raw)

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -273,7 +273,7 @@ recDefsBwd' ρ (NonEmptyList (xcs :| xcss)) =
       NonEmptyList (unwrap (recDefBwd (x ↦ get x ρ) (RecDef xcs)) :| xcss')
 
 recDefBwd :: forall a. BoundedJoinSemilattice a => Bind (Elim a) -> Raw RecDef -> RecDef a
-recDefBwd (x ↦ σ) (RecDef rds) = RecDef (map (x × _) (clausesBwd σ (map snd rds)))
+recDefBwd (x ↦ σ) (RecDef bs) = RecDef ((x × _) <$> unwrap (clausesBwd' σ (Clauses (snd <$> bs))))
 
 -- e, s desugar_bwd s'
 exprBwd :: forall a. BoundedJoinSemilattice a => E.Expr a -> Raw Expr -> Expr a

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -319,9 +319,7 @@ exprBwd (E.App (E.Lambda σ) e1) (ListComp _ _ (Declaration (VarDef π _) : _)) 
          ListComp β s2' (Declaration (VarDef π (desugBwd' e1)) : qs')
       _ -> error absurd
 -- list-comp-gen
-exprBwd
-   (E.App (E.App (E.Var "concatMap") (E.Lambda σ)) e1)
-   (ListComp _ _ (Generator p _ : _)) =
+exprBwd (E.App (E.App (E.Var "concatMap") (E.Lambda σ)) e1) (ListComp _ _ (Generator p _ : _)) =
    let
       σ' × β = orElseBwd (ContElim σ) (Left p : Nil)
    in

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -109,17 +109,17 @@ econs α e e' = E.Constr α cCons (e : e' : Nil)
 elimBool :: forall a. Cont a -> Cont a -> Elim a
 elimBool κ κ' = ElimConstr (D.fromFoldable [ cTrue × κ, cFalse × κ' ])
 
--- Surface language supports "blocks" of variable declarations; core does not.
+-- Module. Surface language supports "blocks" of variable declarations; core does not. Currently no backward.
 moduleFwd :: forall a. JoinSemilattice a => Module a -> MayFail (E.Module a)
-moduleFwd (Module ds) = E.Module <$> traverse varDefOrRecDefsFwd (join (desugarDefs <$> ds))
+moduleFwd (Module ds) = E.Module <$> traverse varDefOrRecDefsFwd (join (flatten <$> ds))
    where
    varDefOrRecDefsFwd :: VarDef a + RecDefs a -> MayFail (E.VarDef a + E.RecDefs a)
    varDefOrRecDefsFwd (Left d) = Left <$> varDefFwd d
    varDefOrRecDefsFwd (Right xcs) = Right <$> recDefsFwd xcs
 
-   desugarDefs :: VarDefs a + RecDefs a -> List (VarDef a + RecDefs a)
-   desugarDefs (Left ds') = Left <$> toList ds'
-   desugarDefs (Right δ) = pure (Right δ)
+   flatten :: VarDefs a + RecDefs a -> List (VarDef a + RecDefs a)
+   flatten (Left ds') = Left <$> toList ds'
+   flatten (Right δ) = pure (Right δ)
 
 varDefFwd :: forall a. JoinSemilattice a => VarDef a -> MayFail (E.VarDef a)
 varDefFwd (VarDef π s) = E.VarDef <$> pattContFwd π (ContNone :: Cont a) <*> desugFwd' s

--- a/src/Trace.purs
+++ b/src/Trace.purs
@@ -8,6 +8,7 @@ import Data.List (List)
 import Data.Maybe (Maybe)
 import Data.Set (Set, empty, singleton, unions)
 import DataType (Ctr)
+import Desugarable (Sugar')
 import Dict (Dict)
 import Expr (class BV, RecDefs, bv, Expr)
 import Lattice (Raw)
@@ -26,7 +27,7 @@ data Trace
    | App Trace Trace AppTrace
    | Let VarDef Trace
    | LetRec (Raw RecDefs) Trace
-   | Sugar (Raw Expr) Trace
+   | Sugar (Sugar' Expr) Trace
 
 data AppTrace
    = AppClosure (Set Var) Match Trace

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -144,3 +144,10 @@ assoc1 ((a × b) × c) = a × (b × c)
 
 assoc2 :: forall a b c. a × (b × c) -> (a × b) × c
 assoc2 (a × (b × c)) = (a × b) × c
+
+-- Not sure what provision there is for composition of functors with types
+data WithTypeLeft (t :: Type) (f :: Type -> Type) a = WithTypeLeft t (f a)
+infixr 6 type WithTypeLeft as <×|
+infixr 6 WithTypeLeft as <×|
+
+derive instance Functor f => Functor (t <×| f)

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -147,6 +147,7 @@ assoc2 (a × (b × c)) = (a × b) × c
 
 -- Not sure what provision there is for composition of functors with types
 data WithTypeLeft (t :: Type) (f :: Type -> Type) a = WithTypeLeft t (f a)
+
 infixr 6 type WithTypeLeft as <×|
 infixr 6 WithTypeLeft as <×|
 

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -13,8 +13,7 @@ import Test.Spec.Mocha (runMocha)
 import App.Fig (LinkFigSpec, linkResult, loadLinkFig)
 import App.Util (Selector)
 import DataType (dataTypeFor, typeName)
-import Desugarable (desugFwd')
-import SExpr (desugarBwd)
+import Desugarable (desugFwd', desugBwd')
 import Eval (eval)
 import EvalBwd (evalBwd)
 import Lattice (𝔹, bot, erase)
@@ -49,7 +48,7 @@ testWithSetup (File file) expected v_expect_opt setup =
             t × v = successful (eval γ e bot)
             v' = fromMaybe identity (fst <$> v_expect_opt) v
             { γ: γ', e: e' } = evalBwd (erase <$> γ) (erase e) v' t
-            s' = desugarBwd e'
+            s' = desugBwd' e' :: S.Expr _
             _ × v'' = successful (eval γ' (successful (desugFwd' s')) true)
          unless (isGraphical v'') (checkPretty "Value" expected v'')
          case snd <$> v_expect_opt of


### PR DESCRIPTION
Desugaring, and other key parts of the language implementation, use various patterns of bidirectional functions, where different techniques are used to allow the backward function to be defined. These should be extracted into type classes so that the design patterns are more explicitly represented in the code. See  for example `OpFwd` and `OpBwd` used for the FFI.