### PR TITLE
Implementation of sinks/sources that goes via `Dict.toArrayWithKey` rather than `filter` to avoid stack overflow on large graphs

### DIFF
--- a/src/Dict.purs
+++ b/src/Dict.purs
@@ -33,7 +33,7 @@ import Data.Set (fromFoldable, member) as S
 import Data.Tuple (fst, snd)
 import Data.Unfoldable (class Unfoldable)
 import Foreign.Object (Object, keys, toAscUnfoldable, values) as O
-import Foreign.Object (delete, empty, filterKeys, fromFoldable, insert, isEmpty, lookup, member, singleton, size, union, unionWith, update, alter)
+import Foreign.Object (delete, empty, filter, filterKeys, fromFoldable, insert, isEmpty, lookup, member, singleton, size, union, unionWith, update, alter)
 import Util (Endo, type (×), (×), assert, definitely, error)
 
 type Dict a = O.Object a

--- a/src/Dict.purs
+++ b/src/Dict.purs
@@ -33,7 +33,7 @@ import Data.Set (fromFoldable, member) as S
 import Data.Tuple (fst, snd)
 import Data.Unfoldable (class Unfoldable)
 import Foreign.Object (Object, keys, toAscUnfoldable, values) as O
-import Foreign.Object (delete, empty, filter, filterKeys, fromFoldable, insert, isEmpty, lookup, member, singleton, size, union, unionWith, update, alter)
+import Foreign.Object (alter, delete, empty, filter, filterKeys, fromFoldable, insert, isEmpty, lookup, member, singleton, size, toArrayWithKey, union, unionWith, update)
 import Util (Endo, type (×), (×), assert, definitely, error)
 
 type Dict a = O.Object a

--- a/src/Graph.purs
+++ b/src/Graph.purs
@@ -24,8 +24,6 @@ class Set s Vertex <= Graph g s | g -> s where
    -- | Number of vertices in g.
    size :: g -> Int
 
-   -- | Set of all vertices in g
-   vertices :: g -> s Vertex
    sources :: g -> s Vertex
    sinks :: g -> s Vertex
    -- |   op (op g) = g

--- a/src/Graph.purs
+++ b/src/Graph.purs
@@ -24,6 +24,7 @@ class (Semigroup g, Set s Vertex) <= Graph g s | g -> s where
    -- | Number of vertices in g.
    size :: g -> Int
 
+   vertices :: g -> s Vertex
    sources :: g -> s Vertex
    sinks :: g -> s Vertex
    -- |   op (op g) = g

--- a/src/Graph.purs
+++ b/src/Graph.purs
@@ -24,7 +24,6 @@ class (Semigroup g, Set s Vertex) <= Graph g s | g -> s where
    -- | Number of vertices in g.
    size :: g -> Int
 
-   vertices :: g -> s Vertex
    sources :: g -> s Vertex
    sinks :: g -> s Vertex
    -- |   op (op g) = g

--- a/src/Graph/GraphImpl.purs
+++ b/src/Graph/GraphImpl.purs
@@ -19,7 +19,7 @@ import Foreign.Object (runST, filter)
 import Foreign.Object.ST (STObject)
 import Foreign.Object.ST as OST
 import Graph (class Graph, Vertex(..), op, outN)
-import Set (class Set, insert, singleton)
+import Set (class Set, insert, singleton, union)
 import Set as Set
 import Util (type (×), (×), definitely, error, unimplemented)
 
@@ -34,17 +34,31 @@ data GraphImpl2 s = GraphImpl2 {
    sinks :: s Vertex
 }
 
+instance Set s Vertex => Semigroup (GraphImpl2 s) where
+   append (GraphImpl2 g) (GraphImpl2 g') =
+      GraphImpl2 {
+         out: D.unionWith union g.out g'.out,
+         in: D.unionWith union g.in g'.in,
+         sources: error unimplemented,
+         sinks: error unimplemented
+      }
+
 instance Set s Vertex => Graph (GraphImpl2 s) s where
    outN (GraphImpl2 g) α = D.lookup (unwrap α) g.out # definitely "in graph"
    inN g = outN (op g)
    elem α (GraphImpl2 g) = isJust (D.lookup (unwrap α) g.out)
    size (GraphImpl2 g) = D.size g.out
+   vertices (GraphImpl2 g) = Set.fromFoldable $ S.map Vertex $ D.keys g.out
    sinks (GraphImpl2 g) = g.sinks
    sources (GraphImpl2 g) = g.sources
    op (GraphImpl2 g) = GraphImpl2 { out: g.in, in: g.out, sources: g.sinks, sinks: g.sources }
    empty = GraphImpl2 { out: D.empty, in: D.empty, sources: Set.empty, sinks: Set.empty }
 
    fromFoldable _ = error unimplemented
+
+instance Set s Vertex => Semigroup (GraphImpl s) where
+   append (GraphImpl out1 in1) (GraphImpl out2 in2) =
+      GraphImpl (D.unionWith Set.union out1 out2) (D.unionWith Set.union in1 in2)
 
 -- Dict-based implementation, efficient because Graph doesn't require any update operations.
 instance Set s Vertex => Graph (GraphImpl s) s where
@@ -54,6 +68,7 @@ instance Set s Vertex => Graph (GraphImpl s) s where
    elem α (GraphImpl out _) = isJust (D.lookup (unwrap α) out)
    size (GraphImpl out _) = D.size out
 
+   vertices (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys out
    sinks (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty out)
    sources (GraphImpl _ in_) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty in_)
 

--- a/src/Graph/GraphImpl.purs
+++ b/src/Graph/GraphImpl.purs
@@ -48,7 +48,7 @@ instance Set s Vertex => Graph (GraphImpl s) s where
       α_αs' = L.fromFoldable α_αs
 
 -- Naive implementation based on Dict.filter fails with stack overflow on graphs with ~20k vertices.
--- This works but is still slow if the sink sets contain thousands of vertices.
+-- This works but building the set is still slow if there are thousands of sinks.
 sinks' :: forall s. Set s Vertex => AdjMap s -> s Vertex
 sinks' m = D.toArrayWithKey (×) m
    # A.filter (snd >>> Set.isEmpty)

--- a/src/Graph/GraphImpl.purs
+++ b/src/Graph/GraphImpl.purs
@@ -15,76 +15,41 @@ import Data.Newtype (unwrap)
 import Data.Set as S
 import Dict (Dict)
 import Dict as D
-import Foreign.Object (runST, filter)
+import Foreign.Object (runST)
 import Foreign.Object.ST (STObject)
 import Foreign.Object.ST as OST
 import Graph (class Graph, Vertex(..), op, outN)
-import Set (class Set, insert, singleton, union)
+import Set (class Set, insert, singleton)
 import Set as Set
-import Util (type (×), (×), definitely, error, unimplemented)
+import Util (type (×), (×), definitely)
 
 -- Maintain out neighbours and in neighbours as separate adjacency maps with a common domain.
 type AdjMap s = Dict (s Vertex)
-data GraphImpl s = GraphImpl (AdjMap s) (AdjMap s)
-
-data GraphImpl2 s = GraphImpl2 {
-   out :: AdjMap s,
-   in :: AdjMap s,
-   sources :: s Vertex,
-   sinks :: s Vertex
-}
-
-instance Set s Vertex => Semigroup (GraphImpl2 s) where
-   append (GraphImpl2 g) (GraphImpl2 g') =
-      GraphImpl2 {
-         out: D.unionWith union g.out g'.out,
-         in: D.unionWith union g.in g'.in,
-         sources: error unimplemented,
-         sinks: error unimplemented
-      }
-
-instance Set s Vertex => Graph (GraphImpl2 s) s where
-   outN (GraphImpl2 g) α = D.lookup (unwrap α) g.out # definitely "in graph"
-   inN g = outN (op g)
-   elem α (GraphImpl2 g) = isJust (D.lookup (unwrap α) g.out)
-   size (GraphImpl2 g) = D.size g.out
-   vertices (GraphImpl2 g) = Set.fromFoldable $ S.map Vertex $ D.keys g.out
-   sinks (GraphImpl2 g) = g.sinks
-   sources (GraphImpl2 g) = g.sources
-   op (GraphImpl2 g) = GraphImpl2 { out: g.in, in: g.out, sources: g.sinks, sinks: g.sources }
-   empty = GraphImpl2 { out: D.empty, in: D.empty, sources: Set.empty, sinks: Set.empty }
-
-   fromFoldable _ = error unimplemented
+data GraphImpl s = GraphImpl { out :: AdjMap s, in :: AdjMap s }
 
 instance Set s Vertex => Semigroup (GraphImpl s) where
-   append (GraphImpl out1 in1) (GraphImpl out2 in2) =
-      GraphImpl (D.unionWith Set.union out1 out2) (D.unionWith Set.union in1 in2)
+   append (GraphImpl g) (GraphImpl g') =
+      GraphImpl { out: D.unionWith Set.union g.out g'.out, in: D.unionWith Set.union g.in g'.in }
 
 -- Dict-based implementation, efficient because Graph doesn't require any update operations.
 instance Set s Vertex => Graph (GraphImpl s) s where
-   outN (GraphImpl out _) α = D.lookup (unwrap α) out # definitely "in graph"
+   outN (GraphImpl g) α = D.lookup (unwrap α) g.out # definitely "in graph"
    inN g = outN (op g)
+   elem α (GraphImpl g) = isJust (D.lookup (unwrap α) g.out)
+   size (GraphImpl g) = D.size g.out
+   sinks (GraphImpl g) = Set.fromFoldable $ S.map Vertex $ D.keys (D.filter Set.isEmpty g.out)
+   sources (GraphImpl g) = Set.fromFoldable $ S.map Vertex $ D.keys (D.filter Set.isEmpty g.in)
+   op (GraphImpl g) = GraphImpl { out: g.in, in: g.out }
+   empty = GraphImpl { out: D.empty, in: D.empty }
 
-   elem α (GraphImpl out _) = isJust (D.lookup (unwrap α) out)
-   size (GraphImpl out _) = D.size out
-
-   vertices (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys out
-   sinks (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty out)
-   sources (GraphImpl _ in_) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty in_)
-
-   op (GraphImpl out in_) = GraphImpl in_ out
-
-   empty = GraphImpl D.empty D.empty
-
-   fromFoldable α_αs = GraphImpl out in_
+   fromFoldable α_αs = GraphImpl { out: runST (outMap α_αs'), in: runST (inMap α_αs') }
       where
       α_αs' = L.fromFoldable α_αs
-      out × in_ = runST (outMap α_αs') × runST (inMap α_αs')
 
 -- In-place update of mutable object to calculate opposite adjacency map.
 type MutableAdjMap s r = STObject r (s Vertex)
 
-addIfMissing :: forall s r. Set s Vertex => STObject r (s Vertex) -> Vertex -> ST r (STObject r (s Vertex))
+addIfMissing :: forall s r. Set s Vertex => STObject r (s Vertex) -> Vertex -> ST r (MutableAdjMap s r)
 addIfMissing acc (Vertex β) = do
    OST.peek β acc >>= case _ of
       Nothing -> OST.poke β Set.empty acc
@@ -116,4 +81,4 @@ inMap α_αs = do
          Just αs -> OST.poke β (insert α αs) acc
 
 instance Show (s Vertex) => Show (GraphImpl s) where
-   show (GraphImpl out in_) = "GraphImpl (" <> show out <> " × " <> show in_ <> ")"
+   show (GraphImpl g) = "GraphImpl (" <> show g.out <> " × " <> show g.in <> ")"

--- a/src/Graph/GraphImpl.purs
+++ b/src/Graph/GraphImpl.purs
@@ -27,6 +27,25 @@ import Util (type (×), (×), definitely)
 type AdjMap s = Dict (s Vertex)
 data GraphImpl s = GraphImpl (AdjMap s) (AdjMap s)
 
+data GraphImpl2 s = GraphImpl2 {
+   out :: AdjMap s,
+   in :: AdjMap s,
+   sources :: s Vertex,
+   sinks :: s Vertex
+}
+
+instance Set s Vertex => Graph (GraphImpl2 s) s where
+   outN (GraphImpl2 g) α = D.lookup (unwrap α) g.out # definitely "in graph"
+   inN g = outN (op g)
+   elem α (GraphImpl2 g) = isJust (D.lookup (unwrap α) g.out)
+   size (GraphImpl2 g) = D.size g.out
+   sinks (GraphImpl2 g) = g.sinks
+   sources (GraphImpl2 g) = g.sources
+   op (GraphImpl2 g) = GraphImpl2 { out: g.in, in: g.out, sources: g.sinks, sinks: g.sources }
+   empty = GraphImpl2 { out: D.empty, in: D.empty, sources: Set.empty, sinks: Set.empty }
+
+   fromFoldable α_αs = ?_
+
 -- Dict-based implementation, efficient because Graph doesn't require any update operations.
 instance Set s Vertex => Graph (GraphImpl s) s where
    outN (GraphImpl out _) α = D.lookup (unwrap α) out # definitely "in graph"
@@ -35,7 +54,6 @@ instance Set s Vertex => Graph (GraphImpl s) s where
    elem α (GraphImpl out _) = isJust (D.lookup (unwrap α) out)
    size (GraphImpl out _) = D.size out
 
-   vertices (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys out
    sinks (GraphImpl out _) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty out)
    sources (GraphImpl _ in_) = Set.fromFoldable $ S.map Vertex $ D.keys (filter Set.isEmpty in_)
 

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -411,11 +411,11 @@ instance (Pretty a, Pretty b) => Pretty (a + b) where
    pretty = pretty ||| pretty
 
 instance Pretty (GraphImpl S.Set) where
-   pretty (GraphImpl out in_) =
+   pretty (GraphImpl g) =
       text "GraphImpl \n  " .<>.
          atop
             ( text "{\n" .<>.
-                 atop (text "OUT: " .<>. pretty out) (text "IN: " .<>. pretty in_)
+                 atop (text "OUT: " .<>. pretty g.out) (text "IN: " .<>. pretty g.in)
             )
             (text "}")
 

--- a/src/Set.purs
+++ b/src/Set.purs
@@ -8,7 +8,7 @@ import Data.Unfoldable (class Unfoldable)
 
 -- Potential problem here: Ord instance of Dict (via Foreign.Object) seems to be broken,
 -- which may cause problems for a Dict Unit implementation of Set.
-class (Ord a, Ord (s a), Foldable s) <= Set s a where
+class (Ord a, Ord (s a), Foldable s) <= Set (s :: Type -> Type) a where
    delete :: a -> s a -> s a
    difference :: s a -> s a -> s a
    union :: s a -> s a -> s a

--- a/src/Set.purs
+++ b/src/Set.purs
@@ -12,6 +12,7 @@ class (Ord a, Ord (s a), Foldable s) <= Set s a where
    delete :: a -> s a -> s a
    difference :: s a -> s a -> s a
    union :: s a -> s a -> s a
+   intersection :: s a -> s a -> s a
    insert :: a -> s a -> s a
    isEmpty :: s a -> Boolean
    member :: a -> s a -> Boolean
@@ -22,10 +23,16 @@ class (Ord a, Ord (s a), Foldable s) <= Set s a where
    fromFoldable :: forall f. Foldable f => f a -> s a
    toUnfoldable :: forall f. Unfoldable f => s a -> f a
 
+unions :: forall s f a. Set s a => Foldable f => f (s a) -> s a
+unions = foldl union empty
+
+infix 5 difference as \\
+
 instance Ord a => Set S.Set a where
    delete = S.delete
    difference = S.difference
    union = S.union
+   intersection = S.intersection
    insert = S.insert
    isEmpty = S.isEmpty
    member = S.member
@@ -35,6 +42,3 @@ instance Ord a => Set S.Set a where
    map = S.map
    fromFoldable = S.fromFoldable
    toUnfoldable = S.toUnfoldable
-
-unions :: forall s f a. Set s a => Foldable f => f (s a) -> s a
-unions = foldl union empty

--- a/src/Util.purs
+++ b/src/Util.purs
@@ -24,10 +24,10 @@ infixr 6 Tuple as ×
 
 infixr 6 type Either as + -- standard library has \/
 
-error :: String -> ∀ a. a
+error :: ∀ a. String -> a
 error msg = unsafePerformEffect (throw msg)
 
-assert :: Boolean -> ∀ a. a -> a
+assert :: ∀ a. Boolean -> a -> a
 assert true = identity
 assert false = \_ -> error "Assertion failure"
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -35,11 +35,31 @@ tests =
    , test_graph
    ]
 
---tests = [ test_bwd ]
+--tests = [ test_scratchpad ]
 
 test_scratchpad :: Array (Test Unit)
 test_scratchpad =
-   [ testBwd (File "filter") (File "filter.expect") (botOf >>> selectNthNode 0 neg) "(_8_ _:_ (7 : []))"
+   [ testBwd (File "convolution/edgeDetect") (File "convolution/edgeDetect.expect")
+        (botOf >>> selectCell 1 1 topOf)
+        "_0_, -1, 2, 0, -1,\n\
+        \0, 3, -2, 3, -2,\n\
+        \-1, 1, -5, 0, 4,\n\
+        \1, -1, 4, 0, -4,\n\
+        \1, 0, -3, 2, 0"
+   , testBwd (File "convolution/emboss") (File "convolution/emboss.expect")
+        (botOf >>> selectCell 1 1 topOf)
+        "_5_, 4, 2, 5, 2,\n\
+        \3, 1, 2, -1, -2,\n\
+        \3, 0, 1, 0, -1,\n\
+        \2, 1, -2, 0, 0,\n\
+        \1, 0, -1, -1, -2"
+   , testBwd (File "convolution/gaussian") (File "convolution/gaussian.expect")
+        (botOf >>> selectCell 1 1 topOf)
+        "_38_, 37, 28, 30, 38,\n\
+        \38, 36, 46, 31, 34,\n\
+        \37, 41, 54, 34, 20,\n\
+        \21, 35, 31, 31, 42,\n\
+        \13, 32, 35, 19, 26"
    ]
 
 test_linking :: Array (Test Unit)

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -118,7 +118,7 @@ testWithSetup (File file) fwd_expect v_expect_opt setup =
             log ("Val 𝔹:\n" <> prettyP v𝔹)
             log ("Expr Vertex:\n" <> prettyP eα)
             log ("Val Vertex:\n" <> prettyP vα)
-         -- log ("Graph:\n" <> prettyP g)
+         -- log ("Graph sources:\n" <> prettyP (sources g))
 
          -- | Test backward slicing
          let (αs_out :: S.Set Vertex) = selectVertices vα v𝔹


### PR DESCRIPTION
Closes #706 