### PR TITLE
2 fixes for slicing/filter: `evalBwd` was inconsistent with `eval`; fwd slicing tests need to consider all vertices as potential outputs (not just sources)

### DIFF
--- a/fluid/example/slicing/filter.expect.fld
+++ b/fluid/example/slicing/filter.expect.fld
@@ -1,3 +1,3 @@
 let filter p [] = [];
     filter p (x:xs) = let ys =  filter  p  xs  in  if  p  x  then ( x  _:_  ys ) else  ys 
-in  filter ((<)_5_) _[__8_,4,7,3]
+in  filter ((<)_5_) [_8_,4,7,3]

--- a/src/App/Util.purs
+++ b/src/App/Util.purs
@@ -53,11 +53,11 @@ selectNth 0 δv (Constr α c (v : v' : Nil)) | c == cCons = Constr α c (δv v :
 selectNth n δv (Constr α c (v : v' : Nil)) | c == cCons = Constr α c (v : selectNth (n - 1) δv v' : Nil)
 selectNth _ _ _ = error absurd
 
-selectNthNode :: Int -> Endo 𝔹 -> Selector Val
-selectNthNode 0 δα (Constr α c Nil) | c == cNil = Constr (δα α) c Nil
-selectNthNode 0 δα (Constr α c (v : v' : Nil)) | c == cCons = Constr (δα α) c (v : v' : Nil)
-selectNthNode n δα (Constr α c (v : v' : Nil)) | c == cCons = Constr α c (v : selectNthNode (n - 1) δα v' : Nil)
-selectNthNode _ _ _ = error absurd
+selectNthCell :: Int -> Endo 𝔹 -> Selector Val
+selectNthCell 0 δα (Constr α c Nil) | c == cNil = Constr (δα α) c Nil
+selectNthCell 0 δα (Constr α c (v : v' : Nil)) | c == cCons = Constr (δα α) c (v : v' : Nil)
+selectNthCell n δα (Constr α c (v : v' : Nil)) | c == cCons = Constr α c (v : selectNthCell (n - 1) δα v' : Nil)
+selectNthCell _ _ _ = error absurd
 
 selectSome :: Selector Val
 selectSome (Constr _ c vs) | c == cSome = Constr true c (botOf <$> vs)

--- a/src/EvalBwd.purs
+++ b/src/EvalBwd.purs
@@ -183,7 +183,7 @@ evalBwd' v (T.App t1 t2 t3) =
    { γ, e, α } = evalBwd' u t1
    { γ: γ', e: e', α: α' } = evalBwd' v2 t2
 evalBwd' v (T.Let (T.VarDef w t1) t2) =
-   { γ: γ1 ∨ γ1', e: Let (VarDef σ e1) e2, α: α1 ∨ α2 }
+   { γ: γ1 ∨ γ1', e: Let (VarDef σ e1) e2, α: α1 }
    where
    { γ: γ1γ2, e: e2, α: α2 } = evalBwd' v t2
    γ1 × γ2 = append_inv (bv w) γ1γ2

--- a/src/Graph.purs
+++ b/src/Graph.purs
@@ -23,6 +23,7 @@ class (Semigroup g, Set s Vertex) <= Graph g s | g -> s where
 
    -- | Number of vertices in g.
    size :: g -> Int
+   vertices :: g -> s Vertex
 
    sources :: g -> s Vertex
    sinks :: g -> s Vertex

--- a/src/Graph/GraphImpl.purs
+++ b/src/Graph/GraphImpl.purs
@@ -38,6 +38,7 @@ instance Set s Vertex => Graph (GraphImpl s) s where
    inN g = outN (op g)
    elem α (GraphImpl g) = isJust (D.lookup (unwrap α) g.out)
    size (GraphImpl g) = D.size g.out
+   vertices (GraphImpl g) = Set.fromFoldable $ Set.map Vertex $ D.keys g.out
    sinks (GraphImpl g) = sinks' g.out
    sources (GraphImpl g) = sinks' g.in
    op (GraphImpl g) = GraphImpl { out: g.in, in: g.out }

--- a/src/Graph/Slice.purs
+++ b/src/Graph/Slice.purs
@@ -7,6 +7,7 @@ import Data.List (List(..), (:))
 import Data.List as L
 import Data.Map (Map, lookup, delete, insertWith)
 import Data.Map (empty) as M
+import Data.Set (Set)
 import Data.Tuple (fst)
 import Graph (class Graph, Edge, Vertex, inEdges, inEdges', outN)
 import Graph.GraphWriter (WithGraph, extend, runWithGraph)
@@ -47,23 +48,11 @@ fwdVertex g' h α =
    where
    αs = lookup α h # definitely "in pending map"
 
-selectVertices :: forall s f. Set s Vertex => Apply f => Foldable f => f Vertex -> f Boolean -> s Vertex
-selectVertices vα v𝔹 = αs_v
-   where
-   αs_v = unions (asSet <$> v𝔹 <*> vα)
+selectVertices :: forall f. Apply f => Foldable f => f Vertex -> f Boolean -> Set Vertex
+selectVertices vα v𝔹 = unions (asSet <$> v𝔹 <*> vα)
 
-select𝔹s :: forall s f. Set s Vertex => Functor f => f Vertex -> s Vertex -> f Boolean
-select𝔹s vα αs = v𝔹
-   where
-   v𝔹 = map (flip member αs) vα
-
-{-
-select𝔹s' :: forall s. Set s Vertex => Env Vertex × Expr Vertex -> s Vertex -> Env Boolean × Expr Boolean
-select𝔹s' (γα × eα) αs = γ𝔹 × e𝔹
-   where
-   γ𝔹 = map (flip select𝔹s αs) γα
-   e𝔹 = select𝔹s eα αs
--}
+select𝔹s :: forall f. Functor f => f Vertex -> Set Vertex -> f Boolean
+select𝔹s vα αs = flip member αs <$> vα
 
 asSet :: forall s. Set s Vertex => Boolean -> Vertex -> s Vertex
 asSet true = singleton

--- a/src/Module.purs
+++ b/src/Module.purs
@@ -61,10 +61,10 @@ open :: File -> Aff (S.Expr Unit)
 open = parseProgram (Folder "fluid/example")
 
 loadModule :: forall s. Set s Vertex => File -> Env Vertex -> WithGraphAllocT s Aff (Env Vertex)
-loadModule file γα = do
+loadModule file γ = do
    src <- lift $ lift $ lift $ loadFile (Folder "fluid/lib") file
-   modα <- except (parse src (module_) >>= desugarModuleFwd) >>= traverseModule (const fresh)
-   eval_module γα modα empty <#> (γα <+> _)
+   mod <- except (parse src (module_) >>= desugarModuleFwd) >>= traverseModule (const fresh)
+   eval_module γ mod empty <#> (γ <+> _)
 
 defaultImports :: forall s. Set s Vertex => WithGraphAllocT s Aff (Env Vertex)
 defaultImports = do
@@ -79,12 +79,12 @@ openDefaultImports = do
 
 -- | Evaluates a dataset from an existing graph config (produced by openDefaultImports)
 openDatasetAs :: forall g s. Graph g s => File -> Var -> GraphConfig g -> Aff (GraphConfig g × Env Vertex)
-openDatasetAs file x { g, n, γ: γα } = do
+openDatasetAs file x { g, n, γ } = do
    s <- parseProgram (Folder "fluid") file
-   (g' × n') × (γα' × xv) <- successful <$>
+   (g' × n') × (γ' × xv) <- successful <$>
       ( runWithGraphAllocT (g × n) $ do
            eα <- alloc (successful $ desug s)
-           vα <- eval γα eα empty
-           pure (γα × D.singleton x vα)
+           vα <- eval γ eα empty
+           pure (γ × D.singleton x vα)
       )
-   pure ({ g: g', n: n', γ: γα' } × xv)
+   pure ({ g: g', n: n', γ: γ' } × xv)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,7 +1,7 @@
 module Test.Main where
 
 import Prelude hiding (add)
-import App.Util (selectBarChart_data, selectCell, selectNth, selectNthNode, selectPair, selectSome, select_y)
+import App.Util (selectBarChart_data, selectCell, selectNth, selectNthCell, selectPair, selectSome, select_y)
 import Bindings ((↦))
 import Control.Monad.Trans.Class (lift)
 import Data.Foldable (foldl)
@@ -40,7 +40,7 @@ tests = [ test_scratchpad ]
 
 test_scratchpad :: Test Unit
 test_scratchpad = testBwdMany
-   [ (File "filter") × (File "filter.expect") × (botOf >>> selectNthNode 0 neg) × "(_8_ _:_ (7 : []))"
+   [ (File "filter") × (File "filter.expect") × (botOf >>> selectNthCell 0 neg) × "(_8_ _:_ (7 : []))"
    ]
 
 test_desugaring :: Test Unit
@@ -173,30 +173,30 @@ test_bwd = testBwdMany
            "_20_"
    , (File "divide") × (File "divide.expect") × topOf × "_40.22222222222222_"
    -- TODO: reinstate as part of https://github.com/explorable-viz/fluid/issues/701
-   --   , (File "filter") × (File "filter.expect") × (botOf >>> selectNthNode 0 neg) × "(_8_ _:_ (7 : []))"
-   , (File "intersperse") × (File "intersperse-1.expect") × (botOf >>> selectNthNode 1 neg) ×
+   --   , (File "filter") × (File "filter.expect") × (botOf >>> selectNthCell 0 neg) × "(_8_ _:_ (7 : []))"
+   , (File "intersperse") × (File "intersperse-1.expect") × (botOf >>> selectNthCell 1 neg) ×
         "(1 : (0 _:_ (2 : (0 : (3 : [])))))"
-   , (File "intersperse") × (File "intersperse-2.expect") × (botOf >>> selectNthNode 2 neg) ×
+   , (File "intersperse") × (File "intersperse-2.expect") × (botOf >>> selectNthCell 2 neg) ×
         "(1 _:_ (0 : (2 _:_ (0 : (3 : [])))))"
    , (File "length") × (File "length.expect") × topOf × "_5_"
-   , (File "list-comp") × (File "list-comp-1.expect") × (botOf >>> selectNthNode 1 neg) ×
+   , (File "list-comp") × (File "list-comp-1.expect") × (botOf >>> selectNthCell 1 neg) ×
         "(6.2 : (260 _:_ (19.9 : (91 : []))))"
-   , (File "list-comp") × (File "list-comp-2.expect") × (botOf >>> selectNthNode 2 neg) ×
+   , (File "list-comp") × (File "list-comp-2.expect") × (botOf >>> selectNthCell 2 neg) ×
         "(6.2 : (260 : (19.9 _:_ (91 : []))))"
    , (File "lookup") × (File "lookup.expect") × selectSome × "_Some_ \"Germany\""
-   , (File "map") × (File "map.expect") × (botOf >>> selectNthNode 0 neg >>> selectNthNode 1 neg) ×
+   , (File "map") × (File "map.expect") × (botOf >>> selectNthCell 0 neg >>> selectNthCell 1 neg) ×
         "(5 _:_ (6 _:_ []))"
    , (File "multiply") × (File "multiply.expect") × (const $ Int true 0) × "_0_"
    , (File "nth") × (File "nth.expect") × (const $ Int true 4) × "_4_"
-   , (File "section-5-example") × (File "section-5-example-1.expect") × (botOf >>> selectNthNode 0 neg) ×
+   , (File "section-5-example") × (File "section-5-example-1.expect") × (botOf >>> selectNthCell 0 neg) ×
         "(88 _:_ (6 : (4 : [])))"
    , (File "section-5-example") × (File "section-5-example-2.expect") × (botOf >>> selectNth 1 topOf) ×
         "(_88_ : (_6_ : (_4_ : [])))"
-   , (File "section-5-example") × (File "section-5-example-3.expect") × (botOf >>> selectNthNode 2 neg) ×
+   , (File "section-5-example") × (File "section-5-example-3.expect") × (botOf >>> selectNthCell 2 neg) ×
         "(88 : (6 : (4 _:_ [])))"
-   , (File "zeros") × (File "zeros-1.expect") × (botOf >>> selectNthNode 0 neg >>> selectNthNode 2 neg) ×
+   , (File "zeros") × (File "zeros-1.expect") × (botOf >>> selectNthCell 0 neg >>> selectNthCell 2 neg) ×
         "(0 _:_ (0 : _[]_))"
-   , (File "zeros") × (File "zeros-2.expect") × (botOf >>> selectNthNode 2 neg) × "(0 : (0 : _[]_))"
+   , (File "zeros") × (File "zeros-2.expect") × (botOf >>> selectNthCell 2 neg) × "(0 : (0 : _[]_))"
    , (File "zipWith") × (File "zipWith-1.expect")
         × (botOf >>> selectNth 1 (const $ Float true 25.0))
         ×

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -26,6 +26,7 @@ main = do
    traverse_ run tests
 
 tests :: Array (Test Unit)
+{-
 tests =
    [ test_desugaring
    , test_misc
@@ -34,33 +35,12 @@ tests =
    , test_linking
    , test_graph
    ]
+-}
+tests = [ test_scratchpad ]
 
 test_scratchpad :: Test Unit
 test_scratchpad = testBwdMany
-   [ (File "convolution/edgeDetect") × (File "convolution/edgeDetect.expect")
-        × (botOf >>> selectCell 1 1 topOf)
-        ×
-           "_0_, -1, 2, 0, -1,\n\
-           \0, 3, -2, 3, -2,\n\
-           \-1, 1, -5, 0, 4,\n\
-           \1, -1, 4, 0, -4,\n\
-           \1, 0, -3, 2, 0"
-   , (File "convolution/emboss") × (File "convolution/emboss.expect")
-        × (botOf >>> selectCell 1 1 topOf)
-        ×
-           "_5_, 4, 2, 5, 2,\n\
-           \3, 1, 2, -1, -2,\n\
-           \3, 0, 1, 0, -1,\n\
-           \2, 1, -2, 0, 0,\n\
-           \1, 0, -1, -1, -2"
-   , (File "convolution/gaussian") × (File "convolution/gaussian.expect")
-        × (botOf >>> selectCell 1 1 topOf)
-        ×
-           "_38_, 37, 28, 30, 38,\n\
-           \38, 36, 46, 31, 34,\n\
-           \37, 41, 54, 34, 20,\n\
-           \21, 35, 31, 31, 42,\n\
-           \13, 32, 35, 19, 26"
+   [ (File "filter") × (File "filter.expect") × (botOf >>> selectNthNode 0 neg) × "(_8_ _:_ (7 : []))"
    ]
 
 test_desugaring :: Test Unit
@@ -193,7 +173,7 @@ test_bwd = testBwdMany
            "_20_"
    , (File "divide") × (File "divide.expect") × topOf × "_40.22222222222222_"
    -- TODO: reinstate as part of https://github.com/explorable-viz/fluid/issues/701
-   --   , (File "filter") (File "filter.expect") (botOf >>> selectNthNode 0 neg) "(_8_ _:_ (7 : []))"
+   --   , (File "filter") × (File "filter.expect") × (botOf >>> selectNthNode 0 neg) × "(_8_ _:_ (7 : []))"
    , (File "intersperse") × (File "intersperse-1.expect") × (botOf >>> selectNthNode 1 neg) ×
         "(1 : (0 _:_ (2 : (0 : (3 : [])))))"
    , (File "intersperse") × (File "intersperse-2.expect") × (botOf >>> selectNthNode 2 neg) ×

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -26,7 +26,6 @@ main = do
    traverse_ run tests
 
 tests :: Array (Test Unit)
-{-
 tests =
    [ test_desugaring
    , test_misc
@@ -35,8 +34,10 @@ tests =
    , test_linking
    , test_graph
    ]
--}
+
+{-
 tests = [ test_scratchpad ]
+-}
 
 test_scratchpad :: Test Unit
 test_scratchpad = testBwdMany
@@ -172,8 +173,7 @@ test_bwd = testBwdMany
         ×
            "_20_"
    , (File "divide") × (File "divide.expect") × topOf × "_40.22222222222222_"
-   -- TODO: reinstate as part of https://github.com/explorable-viz/fluid/issues/701
-   --   , (File "filter") × (File "filter.expect") × (botOf >>> selectNthCell 0 neg) × "(_8_ _:_ (7 : []))"
+   , (File "filter") × (File "filter.expect") × (botOf >>> selectNthCell 0 neg) × "(_8_ _:_ (7 : []))"
    , (File "intersperse") × (File "intersperse-1.expect") × (botOf >>> selectNthCell 1 neg) ×
         "(1 : (0 _:_ (2 : (0 : (3 : [])))))"
    , (File "intersperse") × (File "intersperse-2.expect") × (botOf >>> selectNthCell 2 neg) ×

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -25,7 +25,7 @@ import Eval (eval)
 import EvalBwd (evalBwd)
 import EvalGraph (GraphConfig, evalWithConfig)
 import Expr (Expr) as E
-import Graph (Vertex, sinks, sources)
+import Graph (Vertex, sinks, sources, vertices)
 import Graph.GraphImpl (GraphImpl)
 import Graph.Slice (bwdSlice, fwdSlice) as G
 import Graph.Slice (selectVertices, select𝔹s)
@@ -138,7 +138,7 @@ testWithSetup gconfig s fwd_expect v_expect_opt =
                log ("Expr 𝔹 gotten: \n" <> prettyP e𝔹')
                fail "not equal"
             -- | Check graph/trace-based slicing procedures agree on round-tripped value.
-            let v𝔹' = select𝔹s vα (sources gfwd)
+            let v𝔹' = select𝔹s vα (vertices gfwd)
             unless (eq fwd_expect (prettyP v𝔹')) do
                log ("Val 𝔹 expect: \n" <> fwd_expect)
                log ("Val 𝔹 gotten: \n" <> prettyP v𝔹')

--- a/test/Util.purs
+++ b/test/Util.purs
@@ -87,7 +87,7 @@ testWithSetup gconfig s fwd_expect v_expect_opt =
       let src = prettyP s
       s'' <- except $ parse src program
       trace ("Non-Annotated:\n" <> src) \_ -> lift $ do
-         if (not $ eq (erase s) s'') then do
+         if not $ eq (erase s) s'' then do
             liftEffect $ do
                log ("SRC\n" <> show (erase s))
                log ("NEW\n" <> show s'')


### PR DESCRIPTION
Closes #701 