### PR TITLE
Update purs-backend-es library and minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Fluid is an experimental programming language which integrates a bidirectional d
 - Node.js >=14.0.0
 - yarn
 
+### For Windows Users
+- Clone the repository under Ubuntu WSL
+
 ### Notes
-- Run `script/dev-setup.sh` after cloning repository
+- Run `script/setup/dev-setup.sh` after cloning repository
 - Avoid having PureScript installed globally
 - `Add Npm Path` is selected in PureScript IDE extension settings
 - VSCode for Windows users:
@@ -29,6 +32,6 @@ Fluid is an experimental programming language which integrates a bidirectional d
 - Hit Debug in the browser window that opens, and then open Developer Tools or equivalent
 
 #### Running web app
-- `yarn build-website`
-- `yarn serve-website`
+- `yarn build`
+- `yarn serve fluid-org`
 - Open a browser at the served URL (usually `127.0.0.1:8080`)

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "datetime": "^0.0.3",
     "express": "^4.19.2",
     "express-static": "^1.2.6",
+    "http-serve": "^1.0.1",
     "http-shutdown": "^1.2.2",
     "node-process": "^1.0.1",
     "purescript": "^0.15.10"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "puppeteer": "^23.2.0",
     "purescript-language-server": "0.16.6",
     "purescript-psa": "0.8.2",
-    "purs-backend-es": "1.1.0",
+    "purs-backend-es": "1.4.2",
     "purs-tidy": "^0.9.3",
     "spago": "^0.21.0",
     "typescript": "^5.5.3"

--- a/script/setup/dev-setup.sh
+++ b/script/setup/dev-setup.sh
@@ -4,4 +4,4 @@
 set -e
 
 git config --local include.path "../.gitconfig.include" # install Git aliases
-./script/install-hooks.sh
+./script/setup/install-hooks.sh


### PR DESCRIPTION
## Context
During the execution of `yarn build` command, I had an issue with the generated Javascript which seems incorrect. In particular, I had this exception:
 
      [ERROR] Unexpected "..."
     output-es/Parsing.Language/index.js:80:2:
      80 │   ...haskell98Def,
         ╵   ~~~

## Solution
In my case the solution was the update of the `purs-backend-es`, from the version 1.1.0 to the version 1.4.2. 
Commit: #e10e5cb

## Other minor changes

I also made some little changes and fixes

- Adding the `http-serve` library to the package.json (#0831b59)
- Fix the path in `script/setup/dev-setup.sh` (#191177a)
- Update the README.md, adding a little section for Windows Users. (#cd7dd79)

