### PR TITLE
Puppeteer Libraries now all in shared directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "typescript": "^5.5.3"
   },
   "bin": {
-    "fluid": "./dist/fluid/fluid.mjs",
-    "website-test": "./dist/fluid/website-test.js"
+    "fluid": "./dist/fluid/shared/fluid.mjs",
+    "website-test": "./dist/fluid/shared/website-test.js"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.55",
+  "version": "0.7.56",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.54",
+  "version": "0.7.55",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.53",
+  "version": "0.7.54",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/script/bundle-fluid.sh
+++ b/script/bundle-fluid.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xe
 
-FLUID_EXECUTABLE="dist/fluid/fluid.mjs"
+FLUID_EXECUTABLE="dist/fluid/shared/fluid.mjs"
 
 yarn purs-backend-es bundle-app --main Fluid --to $FLUID_EXECUTABLE --platform=node
 yarn purs-backend-es bundle-app --main Test.Fluid --to dist/test/fluid/fluid.mjs --platform=node

--- a/script/bundle-libraries.sh
+++ b/script/bundle-libraries.sh
@@ -2,6 +2,9 @@
 set -xe
 
 ./script/util/bundle-module.sh load-figure.js App.LoadFigure
+# Comes from https://discourse.purescript.org/t/purescript-0-15-spago-affjax/3045/3
+# Using bundle-module.sh results in mixed module, which does not work well, therefore force puppeteer
+# to bundle to CommonJS module
 esbuild ./output-es/Test.Util.Puppeteer/index.js --bundle --platform=node > dist/fluid/shared/webtest-lib.js
 
 

--- a/script/bundle-libraries.sh
+++ b/script/bundle-libraries.sh
@@ -2,7 +2,7 @@
 set -xe
 
 ./script/util/bundle-module.sh load-figure.js App.LoadFigure
-esbuild ./output-es/Test.Util.Puppeteer/index.js --bundle --platform=node > dist/fluid/webtest-lib.js
+esbuild ./output-es/Test.Util.Puppeteer/index.js --bundle --platform=node > dist/fluid/shared/webtest-lib.js
 
 
 WEBTEST_EXECUTABLE="dist/fluid/website-test.js"

--- a/script/bundle-libraries.sh
+++ b/script/bundle-libraries.sh
@@ -2,7 +2,7 @@
 set -xe
 
 ./script/util/bundle-module.sh load-figure.js App.LoadFigure
-./script/util/bundle-module.sh webtest-lib.mjs Test.Util.Puppeteer --platform=node
+esbuild ./output-es/Test.Util.Puppeteer/index.js --bundle --platform=node > dist/fluid/webtest-lib.js
 
 
 WEBTEST_EXECUTABLE="dist/fluid/website-test.js"

--- a/script/bundle-libraries.sh
+++ b/script/bundle-libraries.sh
@@ -5,10 +5,10 @@ set -xe
 esbuild ./output-es/Test.Util.Puppeteer/index.js --bundle --platform=node > dist/fluid/shared/webtest-lib.js
 
 
-WEBTEST_EXECUTABLE="dist/fluid/website-test.js"
+WEBTEST_EXECUTABLE="dist/fluid/shared/website-test.js"
 SHEBANG="#!/usr/bin/env node"
 
-cp website-test.js dist/fluid/website-test.js
+cp website-test.js dist/fluid/shared/website-test.js
 
 if [[ ! -f "$WEBTEST_EXECUTABLE" ]]; then
     echo "Error: File $WEBTEST_EXECUTABLE not found."

--- a/script/bundle-website.sh
+++ b/script/bundle-website.sh
@@ -48,6 +48,6 @@ done
 
 echo "Processing shared js files:"
 cp "${PREFIX:+$PREFIX/}dist/fluid/load-figure.js" dist/$WEBSITE_LISP_CASE/shared
-cp "${PREFIX:+$PREFIX/}dist/fluid/webtest-lib.mjs" dist/$WEBSITE_LISP_CASE/shared
+cp "${PREFIX:+$PREFIX/}dist/fluid/webtest-lib.js" dist/$WEBSITE_LISP_CASE/shared
 cp -r fluid dist/$WEBSITE_LISP_CASE
 echo "Bundled website $WEBSITE"

--- a/script/bundle-website.sh
+++ b/script/bundle-website.sh
@@ -47,7 +47,6 @@ for CHILD in "${TO_COPY[@]}"; do
 done
 
 echo "Processing shared js files:"
-cp "${PREFIX:+$PREFIX/}dist/fluid/load-figure.js" dist/$WEBSITE_LISP_CASE/shared
-cp "${PREFIX:+$PREFIX/}dist/fluid/webtest-lib.js" dist/$WEBSITE_LISP_CASE/shared
+cp -r "${PREFIX:+$PREFIX/}dist/fluid/shared" dist/$WEBSITE_LISP_CASE
 cp -r fluid dist/$WEBSITE_LISP_CASE
 echo "Bundled website $WEBSITE"

--- a/script/util/bundle-module.sh
+++ b/script/util/bundle-module.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -xe
-yarn purs-backend-es bundle-module -m $2 --to dist/fluid/$1 ${@:3} > /dev/null
+yarn purs-backend-es bundle-module -m $2 --to dist/fluid/shared/$1 ${@:3} > /dev/null

--- a/test/Util/Puppeteer.purs
+++ b/test/Util/Puppeteer.purs
@@ -2,8 +2,8 @@ module Test.Util.Puppeteer where
 
 import Prelude
 
-import Control.Promise (Promise)
-import Data.Foldable (for_)
+import Control.Promise (Promise, fromAff)
+import Data.Foldable (for_, sequence_)
 import Data.Function.Uncurried as FU
 import Data.String (Pattern(..), contains)
 import Effect (Effect)
@@ -56,6 +56,9 @@ defaultViewport =
    , isMobile: false
    , width: 1200.0
    }
+
+runTests :: Array (Aff Unit) -> Effect (Promise Unit)
+runTests arr = fromAff $ sequence_ $ arr
 
 testURL :: String -> Array (T.Page -> Aff Unit) -> Array (Aff Unit)
 testURL suffix tests =


### PR DESCRIPTION
I believe all website testing libraries are now located in the appropriate location according to #1203 

Closes #1203 