### PR TITLE
Add command line evaluation instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,10 @@ Fluid examples in the `dist/fluid/fluid/examples` can be evaluated from the comm
 (from the top-level directory):
 
 ```
-cd dist/fluid
 npx fluid evaluate -f <filename>
 ```
 Note that the filename should not include the `.fld` extension, e.g. for the `range.fld` example:
 ```
-% cd dist/fluid
 % npx fluid evaluate -f range
 ((0, 0) : ((0, 1) : ((1, 0) : ((1, 1) : []))))
 Success

--- a/README.md
+++ b/README.md
@@ -22,23 +22,44 @@ Additionally, for Windows users only:
 - Run `./script/setup/dev-setup.sh` from the top-level directory
 - Run `yarn build`
 
-#### Running tests on command line
+## Use
 
-After building, tests can be run from the command line via `yarn test-all`
+The following assumes you have already succesfully run `yarn build` (see above).
 
-#### Running tests in browser
-- As per command-line tests above, but run `yarn test-browser`, which opens
-a browser window.
-- To observe the status of tests, click `Debug` in the browser window, and then open the JavaScript Console for your browser (e.g., via the Developer Tools).
+### Running programs from the command line
 
-#### Running the fluid.org website locally
+Fluid examples in the `dist/fluid/fluid/examples` can be evaluated from the command line as follows
+(from the top-level directory):
 
-(Assumes you have already run `yarn build`)
+```
+cd dist/fluid
+node shared/fluid.mjs evaluate -f <filename>
+```
+Note that the filename should not include the `.fld` extension, e.g. for the `range.fld` example:
+```
+% cd dist/fluid
+% node shared/fluid.mjs evaluate -f range 
+((0, 0) : ((0, 1) : ((1, 0) : ((1, 1) : []))))
+Success
+```
+
+### Running the fluid.org website locally
 
 - `yarn serve fluid-org` (you may be prompted to proceed: type `y`).
 - Open a browser at the served URL (usually `127.0.0.1:8080`)
 
-#### Run Puppeteer tests for page Y of website X
+## Testing
+
+### Running the tests from the command line
+
+After building, tests can be run from the command line via `yarn test-all`
+
+### Running tests in browser
+- As per command-line tests above, but run `yarn test-browser`, which opens
+a browser window.
+- To observe the status of tests, click `Debug` in the browser window, and then open the JavaScript Console for your browser (e.g., via the Developer Tools).
+
+### Run Puppeteer tests for page Y of website X
 
 Rebuild with `puppeteerTests.headless` set to `false` to run in browser. Then:
 - `yarn bundle-website X`

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Fluid examples in the `dist/fluid/fluid/examples` can be evaluated from the comm
 
 ```
 cd dist/fluid
-node shared/fluid.mjs evaluate -f <filename>
+npx fluid evaluate -f <filename>
 ```
 Note that the filename should not include the `.fld` extension, e.g. for the `range.fld` example:
 ```
 % cd dist/fluid
-% node shared/fluid.mjs evaluate -f range 
+% npx fluid evaluate -f range
 ((0, 0) : ((0, 1) : ((1, 0) : ((1, 1) : []))))
 Success
 ```

--- a/package.json
+++ b/package.json
@@ -25,23 +25,22 @@
     "script/util/lisp-case.sh"
   ],
   "scripts": {
-    "tidy": "./script/tidy.sh",
+    "benchmark": "./script/benchmark.sh",
     "build": "./script/build.sh",
     "build-test": "./script/build-test.sh",
     "bundle-fluid": "./script/bundle-fluid.sh",
     "bundle-page": "./script/bundle-page.sh",
     "bundle-website": "./script/bundle-website.sh",
     "bundle-website-all": "./script/bundle-website-all.sh",
+    "npm-publish": "./script/npm-publish.sh",
     "serve": "./script/serve.sh",
     "test": "./script/test.sh",
+    "test-all": "./script/test-all.sh",
     "test-browser": "./script/test.sh --browsers=Chrome --singleRun=false",
     "test-page": "./script/test-page.sh",
     "test-website": "./script/test-website.sh",
     "test-website-all": "./script/test-website-all.sh",
-    "test-all": "./script/test-all.sh",
-    "npm-publish": "./script/npm-publish.sh",
-    "fluid": "./script/fluid.sh",
-    "benchmark": "./script/benchmark.sh"
+    "tidy": "./script/tidy.sh"
   },
   "dependencies": {
     "@codemirror/commands": "6.2.2",

--- a/script/fluid.sh
+++ b/script/fluid.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -xe
-
-node dist/fluid/fluid.mjs "$@"


### PR DESCRIPTION
This PR adds instructions on how to evaluate Fluid programs from the command line. I have also slightly re-ordered content into the README so that running instructions are grouped (under 'Use') and testing then comes afterwards (under 'Testing').