### PR TITLE
Missing file correctly handled in node environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.76",
+  "version": "0.7.77",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.77",
+  "version": "0.7.78",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@explorable-viz/fluid",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Fluid is an experimental programming language which integrates a bidirectional dynamic analysis to connect outputs to data sources in a fine-grained way. Fluid is implemented in PureScript and runs in the browser.",
   "main": "index.js",
   "repository": {

--- a/src/Module/Node.purs
+++ b/src/Module/Node.purs
@@ -12,7 +12,9 @@ module Module.Node
 import Prelude
 
 import Bind (Bind)
+import Control.Monad.Error.Class (try)
 import Control.Monad.Except (class MonadError)
+import Data.Either (either)
 import Data.Maybe (Maybe(..))
 import Effect.Aff.Class (class MonadAff, liftAff)
 import Effect.Exception (Error)
@@ -37,8 +39,8 @@ loadFile folders (F.File file) = do
    where
    exists :: F.File -> m (Maybe String)
    exists (F.File url) = do
-      stats <- liftAff $ stat url
-      pure $ if isFile stats then Just url else Nothing
+      stats <- liftAff $ try (stat url)
+      pure $ if (either (const false) isFile stats) then Just url else Nothing
 
 parseProgram ∷ ∀ m. Array F.Folder -> F.File → AffError m (Raw S.Expr)
 parseProgram = M.parseProgram loadFile


### PR DESCRIPTION
as part of explorable-viz/transparent-text#72, we had an issue where the fluid library path wasn't being loaded correctly. Further, missing files were causing failures rather than returning false. This PR resolves that error as well.