### PR TITLE
Faster vertices initialisation

### DIFF
--- a/src/Graph.purs
+++ b/src/Graph.purs
@@ -59,7 +59,7 @@ class Selectαs a b | a -> b where
    select𝔹s :: b -> Set Vertex -> a
 
 instance (Functor f, Foldable f) => Vertices (f Vertex) where
-   vertices = (singleton <$> _) >>> unions
+   vertices = Set.fromFoldable
 
 instance (Apply f, Foldable f) => Selectαs (f 𝔹) (f Vertex) where
    selectαs v𝔹 vα = unions ((if _ then singleton else const mempty) <$> v𝔹 <*> vα)


### PR DESCRIPTION
This uses fromFoldable which inserts into one set rather than creating singleton sets for each vertex and unioning them.

This significantly reduces blocking time: #1272 