### PR TITLE
Read files as UTF8

### DIFF
--- a/src/Module/Node.purs
+++ b/src/Module/Node.purs
@@ -35,7 +35,7 @@ loadFile folders (F.File file) = do
    url <- findM urls exists Nothing
    case url of
       Nothing -> error $ "File " <> file <> " not found."
-      Just name -> liftAff $ readTextFile ASCII name
+      Just name -> liftAff $ readTextFile UTF8 name
    where
    exists :: F.File -> m (Maybe String)
    exists (F.File url) = do


### PR DESCRIPTION
Read files using utf8, this resolves issues with `.expect` files during test/benchmark as in #1333.