### PR TITLE
Update minimum Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fluid is an experimental programming language which integrates a bidirectional d
 
 ### Software required
 - git
-- Node.js >=14.0.0
+- Node.js >=18.0.0
 - yarn >= 1.22
 
 Additionally, for Windows users only:


### PR DESCRIPTION
Changes node version requirement in README.

Unable to `yarn install` with Node 14:

```
yarn install v1.22.22
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] Resolving packages...
[2/4] Fetching packages...
error commander@12.1.0: The engine "node" is incompatible with this module. Expected version ">=18". Got "14.2.0"
error Found incompatible module.
```

Current LTS is 20 so supporting back to 18 seems OK to me