### PR TITLE
Run `purs-backend-es` with `--no-build`

### DIFF
--- a/script/bundle-benchmark.sh
+++ b/script/bundle-benchmark.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -xe
 
-yarn purs-backend-es bundle-app --main Benchmark --to output-es/Benchmark/index.mjs --platform=node
+yarn purs-backend-es bundle-app --no-build --main Benchmark --to output-es/Benchmark/index.mjs --platform=node

--- a/script/bundle-fluid.sh
+++ b/script/bundle-fluid.sh
@@ -4,7 +4,7 @@ set -xe
 FLUID_EXECUTABLE="dist/fluid/shared/fluid.mjs"
 SHEBANG="#!/usr/bin/env node"
 
-yarn purs-backend-es bundle-app --main Fluid --to $FLUID_EXECUTABLE --platform=node
+yarn purs-backend-es bundle-app --no-build --main Fluid --to $FLUID_EXECUTABLE --platform=node
 
 if [[ ! -f "$FLUID_EXECUTABLE" ]]; then
   echo "Error: File $FLUID_EXECUTABLE not found."

--- a/script/util/bundle-module.sh
+++ b/script/util/bundle-module.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -xe
-yarn purs-backend-es bundle-module -m $2 --to dist/fluid/shared/$1 ${@:3} > /dev/null
+yarn purs-backend-es bundle-module --no-build -m $2 --to dist/fluid/shared/$1 ${@:3} > /dev/null

--- a/script/util/bundle.sh
+++ b/script/util/bundle.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -xe
-yarn purs-backend-es bundle-app --main $2 --to dist/$1/fluid.js ${@:3} > /dev/null
+yarn purs-backend-es bundle-app --no-build --main $2 --to dist/$1/fluid.js ${@:3} > /dev/null


### PR DESCRIPTION
Avoids rebuilding with `purs-backend-es` when bundling. The build happens once during `spago build`.

On my laptop this brings the total build time from ~35s to ~20s.