### PR TITLE
Keep `output` on build and cache for Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,13 @@ jobs:
       run: |
         shopt -s extglob nullglob globstar
       if: runner.os == 'Linux'
+    - name: Cache PureScript dependencies
+      uses: actions/cache@v4
+      with:
+        key: ${{ runner.os }}-spago-${{ hashFiles('**/*.dhall') }}
+        path: |
+          .spago
+          output
     - name: test
       run: |
         yarn install

--- a/script/util/compile.sh
+++ b/script/util/compile.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -xe
 
-rm -rf output
 rm -rf output-es
 yarn tidy
 


### PR DESCRIPTION
The contents of `output` are used by `spago` for incremental builds, so we should not delete it when working locally and could also cache in CI.

Spago itself caches `output` in CI, shared across branches:

https://github.com/purescript/spago/blob/master/.github/workflows/build.yml

So do others:

https://github.com/aristanetworks/purescript-backend-optimizer/blob/main/.github/workflows/ci.yml
https://github.com/purescript-halogen/purescript-halogen/blob/master/.github/workflows/ci.yml

I have been using this locally this week and not had any issues. Builds are faster.

I tested the Workflow changes on a fork. It works and saves a bit of time: https://github.com/jacobpake/fluid/actions/runs/16195275298/job/45720132090

Some discussion here:
https://github.com/purescript/spago/issues/700