### PR TITLE
Fix build config

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -61,6 +61,7 @@ in  { name = ""
       , "web-events"
       ]
     , packages = ./packages.dhall
+    , baseSources
     , sources = baseSources # [ "config/dev/**/*.purs" ]
     , backend = "npx purs-backend-es build"
     }


### PR DESCRIPTION
Default config needs to have `baseSources` for reference by prod config

This line got removed and broke `yarn build-prod`