### PR TITLE
Use `purs-tidy` glob handler

### DIFF
--- a/script/tidy.sh
+++ b/script/tidy.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 set -xe
 
-# Got bored of trying to make recursive globs work cross-platform
 yarn purs-tidy format-in-place \
-   src/*.purs \
-   src/**/*.purs \
-   src/App/**/*.purs \
-   src/App/View/**/*.purs \
-   test/*.purs \
-   test/**/*.purs \
-   website/*.purs \
-   website/**/*.purs \
-   config/*.purs \
-   config/**/*.purs \
+   "src/**/*.purs" \
+   "test/**/*.purs" \
+   "website/**/*.purs" \
+   "config/**/*.purs" \
    > /dev/null


### PR DESCRIPTION
The `**/*` pattern doesn't work as expected out of the box in bash, hence the need for additions like `src/App/View/**/*.purs` when we want to tidy files two levels deep.

Wrapping the patterns in quotes will use `purs-tidy` built in glob handler which works as expected.

I have tested on MacOS and Linux, I assume it will work fine in WSL.

To test, you can untidy a file like `src/App/View/Util/D3.purs` and see if it gets tidied.