### PR TITLE
Infix `and` and `or` without delimiters

### DIFF
--- a/fluid/lib/matrix.fld
+++ b/fluid/lib/matrix.fld
@@ -1,6 +1,6 @@
 def zero(m, n, image):
   def (m_max, n_max): dims(image)
-  if m >= 1 |and| m <= m_max |and| n >= 1 |and| n <= n_max: image ! (m, n)
+  if m >= 1 and m <= m_max and n >= 1 and n <= n_max: image ! (m, n)
   else: 0
 
 def wrap(m, n, image):

--- a/fluid/lib/prelude.fld
+++ b/fluid/lib/prelude.fld
@@ -87,7 +87,7 @@ def tail(_ :| xs): xs
 # Eq a => a -> List a -> Bool
 def elem(x, []): False
 def elem(x, y :| xs):
-  x == y |or| elem(x, xs)
+  x == y or elem(x, xs)
 
 # (a -> Bool) -> List a -> Option a
 def find(p, []): None

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -76,6 +76,11 @@ binaryOp op = do
    reservedOperator op
    pure \e e' -> BinaryApp e op e'
 
+binaryOpIdent :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+binaryOpIdent op = do
+   reserved op
+   pure \e e' -> BinaryApp e op e'
+
 infixFn :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
 infixFn = do
    fn <- try (delim '|' *> variable)
@@ -107,6 +112,8 @@ binaryOps =
      , Infix (binaryOp "<=") AssocLeft
      , Infix (binaryOp ">=") AssocLeft
      ]
+   , [ Infix (binaryOpIdent "and") AssocLeft ]
+   , [ Infix (binaryOpIdent "or") AssocLeft ]
    , [ Infix infixFn AssocLeft ]
    ]
 

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -33,5 +33,6 @@ opDefs = fromFoldable
    , opDef ">" 4 AssocLeft
    , opDef "<=" 4 AssocLeft
    , opDef ">=" 4 AssocLeft
+   , opDef "and" 3 AssocLeft
+   , opDef "or" 2 AssocLeft
    ]
-

--- a/test/Specs/Misc.purs
+++ b/test/Specs/Misc.purs
@@ -6,6 +6,7 @@ misc_cases :: Array TestSpec
 misc_cases =
    [ { file: "arithmetic.fld", fwd_expect: "42" }
    , { file: "array.fld", fwd_expect: "(1, (3, 3))" }
+   , { file: "boolean-precedence.fld", fwd_expect: "True" }
    , { file: "compose.fld", fwd_expect: "5" }
    , { file: "dicts.fld"
      , fwd_expect: "{ d: {}, e: { a: 5, ab: 6 }, e_ab: 6, f: { a: 6, ab: 7 }, g: { a: 5 } }"

--- a/test/fluid/boolean-precedence.fld
+++ b/test/fluid/boolean-precedence.fld
@@ -1,0 +1,5 @@
+not(
+   (True or False and False) # True
+       and
+   ((True or False) and False) # False
+)

--- a/test/fluid/lib/dtw.fld
+++ b/test/fluid/lib/dtw.fld
@@ -5,7 +5,7 @@ def nextIndices(n, m, window):
 
 def costMatrixInit(rows, cols, window):
   def initV(n, m):
-    if (n == 1 |and| m == 1) |or| (abs(n, m) <= window |and| not(n == 1 |or| m == 1)): FNum(0)
+    if (n == 1 and m == 1) or (abs(n, m) <= window and not(n == 1 or m == 1)): FNum(0)
     else: Infty
   [| initV(n, m) for (n, m) in (rows, cols) |]
 
@@ -19,7 +19,7 @@ def minAndPrev((i, j), im1, jm1, ijm1):
     else: ((i, j), minim)
 
 def extractPath(indmatrix, (n, m), accum):
-  if n == 1 |and| m == 1: accum
+  if n == 1 and m == 1: accum
   else:
     extractPath(indmatrix, indmatrix ! (n, m), (n - 1, m - 1) :| accum)
 

--- a/website/article/fluid/convolution.fld
+++ b/website/article/fluid/convolution.fld
@@ -3,7 +3,7 @@ import convolution.emboss     # defines filter
 
 def lookup(m, n, image):
   def (m_max, n_max): dims(image)
-  if m >= 1 |and| m <= m_max |and| n >= 1 |and| n <= n_max:
+  if m >= 1 and m <= m_max and n >= 1 and n <= n_max:
     image!(m, n)
   else: 0 # pad with zeros
 

--- a/website/article/fluid/scigen.fld
+++ b/website/article/fluid/scigen.fld
@@ -11,7 +11,7 @@ def ordinal(n):
     if n < 4:
       numToStr(n) ++ findWithKey_("lastDigit", n, ordinalMap).suffix
     else:
-      if n >= 4 |and| n <= 20:
+      if n >= 4 and n <= 20:
          numToStr(n) ++ "th"
       else:
         error("n > 20 not supported")

--- a/website/literate-execution/evaluation-nap3/figure1/figure1.fld
+++ b/website/literate-execution/evaluation-nap3/figure1/figure1.fld
@@ -10,7 +10,7 @@ def actions_by(key, keys):
         { y: eval_score,
           z: count_if(
             lambda action:
-              action[ key ] == key_ |and| action[ "Evaluation score" ] == eval_score,
+              action[ key ] == key_ and action[ "Evaluation score" ] == eval_score,
             nap3_actions
           ) } for eval_score in eval_scores
       ] } for key_ in keys
@@ -25,7 +25,7 @@ def actions_by_chapter:
         { y: eval_score,
           z: count_if(
             lambda action:
-              risks_[ action[ "Risk ID#" ] ][ "Chapter" ] == chapter |and|
+              risks_[ action[ "Risk ID#" ] ][ "Chapter" ] == chapter and
               action[ "Evaluation score" ] == eval_score,
             nap3_actions
           ) } for eval_score in eval_scores


### PR DESCRIPTION
Allows use of `and` and `or` prelude functions without surrounding pipes per https://github.com/explorable-viz/fluid/issues/1418

Follows Pythons precedence rules where and > or with left-to-right associativity.

I have updated all occurrences I could find, including in `prelude.fld` and `matrix.fld`, and the tests pass.

I have not checked the website behaviour for the following programs, but the uses look like the update should be harmless.

```
website/article/fluid/convolution.fld
website/article/fluid/scigen.fld
website/literate-execution/evaluation-nap3/figure1/figure1.fld
```