### PR TITLE
Support `def` inside list comprehension 

### DIFF
--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -361,20 +361,18 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
                                     reserved "if"
                                     e' <- opTree
                                     pure $ ListCompGuard e'
-                               , do
+                               , context "listCompDecl" do
+                                    reserved "def"
+                                    p <- pattern
+                                    delim ':'
+                                    e' <- opTree
+                                    pure $ ListCompDecl (VarDef p e')
+                               , context "listCompGen" do
                                     reserved "for"
                                     p <- pattern
                                     reserved "in"
-                                    choice
-                                       [ context "listCompDecl" $ try do
-                                            delim '['
-                                            e' <- opTree
-                                            delim ']'
-                                            pure $ ListCompDecl (VarDef p e')
-                                       , context "listCompGen" do
-                                            e' <- opTree
-                                            pure $ ListCompGen p e'
-                                       ]
+                                    e' <- opTree
+                                    pure $ ListCompGen p e'
                                ]
                             close ']'
                             pure $ ListComp unit e (toList qs)

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -158,7 +158,7 @@ instance Ann a => Pretty (Expr a) where
 
 instance Ann a => Pretty (List (Qualifier a)) where
    pretty (Cons (ListCompDecl (VarDef v s)) Nil) =
-      text "for" <+> pretty v <+> text "in" <+> brackets (pretty s)
+      text "def" <+> pretty v <> text ":" <+> pretty s
    pretty (Cons (ListCompGuard s) Nil) = text "if" <+> pretty s
    pretty (Cons (ListCompGen p s) Nil) = text "for" <+> pretty p <+> text "in" <+> pretty s
    pretty (Cons q qs) = pretty (singleton q) <+> pretty qs

--- a/test/fluid/desugar/list-comp-2.fld
+++ b/test/fluid/desugar/list-comp-2.fld
@@ -1,1 +1,1 @@
-[z for x in [5, 4, 3] for y in [9, 7, 5] for z in [x + y] for c in [9, 7, 5]]
+[z for x in [5, 4, 3] for y in [9, 7, 5] def z: x + y for c in [9, 7, 5]]

--- a/test/fluid/desugar/list-comp-3.fld
+++ b/test/fluid/desugar/list-comp-3.fld
@@ -1,1 +1,1 @@
-[z for x in [5, 4, 3] for y in [9, 7, 5] for z in [x + y] if z < 10]
+[z for x in [5, 4, 3] for y in [9, 7, 5] def z: x + y if z < 10]

--- a/test/fluid/desugar/list-comp-5.fld
+++ b/test/fluid/desugar/list-comp-5.fld
@@ -1,1 +1,1 @@
-[z for x in [5, 4, 3] for z in [x]]
+[z for x in [5, 4, 3] def z: x]

--- a/test/fluid/desugar/list-comp-6.fld
+++ b/test/fluid/desugar/list-comp-6.fld
@@ -1,1 +1,1 @@
-[z for z in [5]]
+[z def z: 5]


### PR DESCRIPTION
Supports declarations inside of a list comprehension.

This was supported in the previous syntax as:

```
[ z | x <- [1, 2, 3], let z = x + 1 ]
```

There is no direct equivalent in Python to take inspiration from, but it is possible to achieve the same effect in the new syntax with:

```
[z for x in [1, 2, 3] for z in [x + 1]]
```

The purpose of this PR is to reintroduce a dedicated syntax for declarations such as:

```
[z for x in [1, 2, 3] def z: x + 1]
[z for x in [5, 4, 3] for y in [9, 7, 5] def g: x + y def z: g if z < 10]
```

Because of the lack of delimitation between `defs` and `if x` guards, some care will need to be taken when implementing ternary conditional expressions in #1415.


Fixes #433

