### PR TITLE
Rename `range` and `enumFromTo`

### DIFF
--- a/fluid/lib/matrix.fld
+++ b/fluid/lib/matrix.fld
@@ -17,7 +17,7 @@ def extend(m, n, image):
 
 def matrixSum(matr):
   def (m, n): dims(matr)
-  foldl((+), 0, [matr ! (i, j) for (i, j) in range((1, 1), (m, n))])
+  foldl((+), 0, [matr ! (i, j) for (i, j) in range2((1, 1), (m, n))])
 
 def convolve(image, kernel, lookup):
   def ((m, n), (i, j)):
@@ -37,4 +37,4 @@ def matMul(a, b):
     error("Dimensions don't line up")
   else:
     @doc(f"""Intermediate matrix""")
-    [| sum([a!(i_, k) * b!(k, j_) for k in enumFromTo(1, n)]) for (i_, j_) in (m, j) |]
+    [| sum([a!(i_, k) * b!(k, j_) for k in range(1, n)]) for (i_, j_) in (m, j) |]

--- a/fluid/lib/matrix.fld
+++ b/fluid/lib/matrix.fld
@@ -17,7 +17,7 @@ def extend(m, n, image):
 
 def matrixSum(matr):
   def (m, n): dims(matr)
-  foldl((+), 0, [matr ! (i, j) for (i, j) in range2((1, 1), (m, n))])
+  foldl((+), 0, [matr ! (i, j) for (i, j) in range2d((1, 1), (m, n))])
 
 def convolve(image, kernel, lookup):
   def ((m, n), (i, j)):

--- a/fluid/lib/prelude.fld
+++ b/fluid/lib/prelude.fld
@@ -303,15 +303,13 @@ def zipWith(op, x :| xs, y :| ys):
 # List a -> List b -> List (a, b)
 def zip: zipWith(curry(id))
 
-# Rename to 'range'
 # Int -> Int -> List Int
-def enumFromTo(n, m):
+def range(n, m):
   if n <= m: n :| [n + 1 .. m]
   else: []
 
-# Rename to 'range2'
 # (Int, Int) -> (Int, Int) -> List (Int, Int)
-def range((m1, n1), (m2, n2)):
+def range2((m1, n1), (m2, n2)):
   [(i1, i2) for i1 in [m1 .. m2] for i2 in [n1 .. n2]]
 
 # Int -> Int -> Int

--- a/fluid/lib/prelude.fld
+++ b/fluid/lib/prelude.fld
@@ -309,7 +309,7 @@ def range(n, m):
   else: []
 
 # (Int, Int) -> (Int, Int) -> List (Int, Int)
-def range2((m1, n1), (m2, n2)):
+def range2d((m1, n1), (m2, n2)):
   [(i1, i2) for i1 in [m1 .. m2] for i2 in [n1 .. n2]]
 
 # Int -> Int -> Int

--- a/fluid/lib/stats.fld
+++ b/fluid/lib/stats.fld
@@ -44,7 +44,7 @@ def cut(xs, nbins):
   def binwidth:
     (maximum(xs) - low) / nbins
   def edges:
-    [low + x * binwidth for x in enumFromTo(0, nbins)]
+    [low + x * binwidth for x in range(0, nbins)]
 
   accumBins(xs, edges)
 

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -325,7 +325,7 @@ exprFwd (ListEmpty α) =
 exprFwd (ListNonEmpty α s l) =
    econs α <$> desug s <*> desug l
 exprFwd (ListEnum s1 s2) =
-   E.App <$> (E.App (E.Var "enumFromTo") <$> desug s1) <*> desug s2
+   E.App <$> (E.App (E.Var "range") <$> desug s1) <*> desug s2
 exprFwd (ListComp α s (ListCompGen p s' : qs)) = unsafePartial $
    listCompFwd (α × (ListCompGen p s' : qs) × s)
 exprFwd (ListComp α s qs) =
@@ -374,7 +374,7 @@ exprBwd (E.Constr α _ Nil) (ListEmpty _) =
    ListEmpty α
 exprBwd (E.Constr α _ (e1 : e2 : Nil)) (ListNonEmpty _ s l) =
    ListNonEmpty α (desugBwd e1 s) (desugBwd e2 l)
-exprBwd (E.App (E.App (E.Var "enumFromTo") e1) e2) (ListEnum s1 s2) =
+exprBwd (E.App (E.App (E.Var "range") e1) e2) (ListEnum s1 s2) =
    ListEnum (desugBwd e1 s1) (desugBwd e2 s2)
 exprBwd e@(E.App (E.App _ _) _) (ListComp _ s (q@(ListCompGen _ _) : qs)) =
    let α × qs' × s' = listCompBwd e ((q : qs) × s) in ListComp α s' qs'

--- a/website/article/fluid/convolution.fld
+++ b/website/article/fluid/convolution.fld
@@ -9,7 +9,7 @@ def lookup(m, n, image):
 
 def matrixSum(matr):
   def (m, n): dims(matr)
-  foldl((+), 0, [matr!(i, j) for (i, j) in range2((1, 1), (m, n))])
+  foldl((+), 0, [matr!(i, j) for (i, j) in range2d((1, 1), (m, n))])
 
 def convolve(image, kernel):
   def (k_i, k_j): dims(kernel)

--- a/website/article/fluid/convolution.fld
+++ b/website/article/fluid/convolution.fld
@@ -9,7 +9,7 @@ def lookup(m, n, image):
 
 def matrixSum(matr):
   def (m, n): dims(matr)
-  foldl((+), 0, [matr!(i, j) for (i, j) in range((1, 1), (m, n))])
+  foldl((+), 0, [matr!(i, j) for (i, j) in range2((1, 1), (m, n))])
 
 def convolve(image, kernel):
   def (k_i, k_j): dims(kernel)


### PR DESCRIPTION
Renames `range` to `range2d` and `enumFromTo` to `range`.

Updates occurences in `lib/fluid` and in `website/article`.

Fixes #1417 