### PR TITLE
Drop primes from identifier syntax

### DIFF
--- a/fluid/lib/matrix.fld
+++ b/fluid/lib/matrix.fld
@@ -9,11 +9,11 @@ def wrap(m, n, image):
 
 def extend(m, n, image):
   def (m_max, n_max): dims(image)
-  def m':
+  def m_:
     min(max(m, 1), m_max)
-  def n':
+  def n_:
     min(max(n, 1), n_max)
-  image ! (m', n')
+  image ! (m_, n_)
 
 def matrixSum(matr):
   def (m, n): dims(matr)
@@ -25,10 +25,10 @@ def convolve(image, kernel, lookup):
   def (half_i, half_j):
     (i |quot| 2, j |quot| 2)
   def area: i * j
-  def interMatrix(m', n'):
-    [| lookup(((m' + i') - 1) - half_i, ((n' + j') - 1) - half_j, image) * kernel ! (i', j') for (i', j') in (i, j) |]
+  def interMatrix(m_, n_):
+    [| lookup(((m_ + i_) - 1) - half_i, ((n_ + j_) - 1) - half_j, image) * kernel ! (i_, j_) for (i_, j_) in (i, j) |]
 
-  [| matrixSum(interMatrix(m', n')) |quot| area for (m', n') in (m, n) |]
+  [| matrixSum(interMatrix(m_, n_)) |quot| area for (m_, n_) in (m, n) |]
 
 def matMul(a, b):
   def ((m, n), (i, j)): (dims(a), dims(b))

--- a/src/Parse/Parser.purs
+++ b/src/Parse/Parser.purs
@@ -86,14 +86,14 @@ unreserved p = do
    else pure name
 
 variable :: Parser String
-variable = unreserved $ identifier (lower <|> char '_') (alphaNum <|> oneOf [ '_', '\'' ])
+variable = unreserved $ identifier (lower <|> char '_') (alphaNum <|> char '_')
 
 constructor :: Parser String
-constructor = unreserved $ identifier upper (alphaNum <|> oneOf [ '_', '\'' ])
+constructor = unreserved $ identifier upper (alphaNum <|> char '_')
 
 reserved :: String -> Parser Unit
 reserved expected = try do
-   received <- identifier (letter <|> char '_') (alphaNum <|> oneOf [ '_', '\'' ])
+   received <- identifier (letter <|> char '_') (alphaNum <|> char '_')
    if expected /= received then fail $ "Expected `" <> expected <> "`, received `" <> received <> "`"
    else pure unit
 

--- a/test/fluid/linkedInputs/energyscatter.fld
+++ b/test/fluid/linkedInputs/energyscatter.fld
@@ -10,12 +10,12 @@ def plot(year, countries):
     filter(isYear(year), nonRenewables)
 
   def plotCountry(country):
-    def rens':
+    def rens_:
       filter(isCountry(country), rens)
     def rensOut:
-      sum(map(lambda x: x.output, rens'))
+      sum(map(lambda x: x.output, rens_))
     def rensCap:
-      sum(map(lambda x: x.capacity, rens'))
+      sum(map(lambda x: x.capacity, rens_))
     def x:
       head(filter(isCountry(country), nonRens))
     def nonRensCap:

--- a/test/fluid/linkedOutputs/moving-average.fld
+++ b/test/fluid/linkedOutputs/moving-average.fld
@@ -4,7 +4,7 @@ def nthPad(n, xs):
   nth(min(max(n, 0), length(xs) - 1), xs)
 def movingAvg(ys, window):
   [sum([nthPad(n, ys) for n in [i - window .. i + window]]) / (1 + 2 * window) for i in [0 .. length(ys) - 1]]
-def movingAvg'(rs, window):
+def movingAvg_(rs, window):
   zipWith(lambda x, y: { x: x, y: y }, map(lambda r: r.x, rs), movingAvg(map(lambda r: r.y, rs), window))
 
 def points:
@@ -17,7 +17,7 @@ LineChart({
   plots: [
     LinePlot({
       name: "Moving average",
-      points: movingAvg'(points, 1)
+      points: movingAvg_(points, 1)
     }),
     LinePlot({ name: "Original curve", points: points })
   ]

--- a/test/fluid/mergeSort.fld
+++ b/test/fluid/mergeSort.fld
@@ -6,10 +6,10 @@ def split(x :| xs):
 def merge(xs, ys):
   match (xs, ys):
     case ([], _): ys
-    case (x :| xs', []): xs
-    case (x :| xs', y :| ys'):
-      if x < y: x :| merge(xs', ys)
-      else: y :| merge(xs, ys')
+    case (x :| xs_, []): xs
+    case (x :| xs_, y :| ys_):
+      if x < y: x :| merge(xs_, ys)
+      else: y :| merge(xs, ys_)
 
 def mergesort(xs):
   if length(xs) < 2: xs

--- a/test/fluid/slicing/dict/map.expect.fld
+++ b/test/fluid/slicing/dict/map.expect.fld
@@ -4,6 +4,6 @@ def incHead:
   lambda xs: head(xs) + x
 def d: { a: [⸨5⸩, 6], b: [⸨9⸩, 10], c: [3, 4] }
 def e: { c: [] }
-def d': dict_map(incHead, dict_difference(d, e))
+def d_: dict_map(incHead, dict_difference(d, e))
 
-d'.a + d'.b
+d_.a + d_.b

--- a/test/fluid/slicing/dict/map.fld
+++ b/test/fluid/slicing/dict/map.fld
@@ -4,7 +4,7 @@ def incHead:
   lambda xs: head(xs) + x
 def d: { a: [5, 6], b: [9, 10], c: [3, 4] }
 def e: { c: [] }
-def d':
+def d_:
   dict_map(incHead, dict_difference(d, e))
 
-d'.a + d'.b
+d_.a + d_.b

--- a/test/fluid/slicing/matrix-update.expect.fld
+++ b/test/fluid/slicing/matrix-update.expect.fld
@@ -1,4 +1,4 @@
-def image':
+def image_:
   [
     [15, 13, 6, 9, 16],
     [12, 5, 15, 4, 13],
@@ -6,7 +6,7 @@ def image':
     [4, 10, 3, 7, 19],
     [3, 11, 15, 2, 9]
   ]
-def image: [| nth2(i, j, image') for (i, j) in (5, 5)|]
+def image: [| nth2(i, j, image_) for (i, j) in (5, 5)|]
 def index: (2, 2)
 def pair: ⸨4000⸩
 

--- a/test/fluid/slicing/matrix-update.fld
+++ b/test/fluid/slicing/matrix-update.fld
@@ -1,4 +1,4 @@
-def image': [
+def image_: [
   [15, 13, 6, 9, 16],
   [12, 5, 15, 4, 13],
   [14, 9, 20, 8, 1],
@@ -6,7 +6,7 @@ def image': [
   [3, 11, 15, 2, 9]
 ]
 def image:
-  [| nth2(i, j, image') for (i, j) in (5, 5) |]
+  [| nth2(i, j, image_) for (i, j) in (5, 5) |]
 def index: (2, 2)
 def pair: 4000
 


### PR DESCRIPTION
- No longer parses `'` as an identifier character
- Replaces all occurrences of `id'` with `id_`

per #1410