### PR TITLE
Reorganise operator table construction / reference

### DIFF
--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -5,7 +5,8 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Lazy (defer)
 import Control.Monad.State (StateT)
-import Data.Array (fromFoldable, some)
+import Data.Array (fromFoldable, groupBy, some, sortBy)
+import Data.Array.NonEmpty (head, toArray)
 import Data.Bifunctor (lmap)
 import Data.CodePoint.Unicode (isSpace)
 import Data.Either (Either, choose)
@@ -25,6 +26,7 @@ import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
 import Parsing.Expr (Assoc(..), Operator(..), OperatorTable, buildExprParser)
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
+import Primitive.Parse (OpDef, OpType(..), opDefs)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (+), type (×), nonEmpty, (×))
 
@@ -94,30 +96,19 @@ consOp = do
 
 binaryOps :: OperatorTable (StateT Position Identity) String (Raw Expr)
 binaryOps =
-   [ [ Infix (binaryOp "!") AssocLeft
-     , Infix (binaryOp "**") AssocRight
-     ]
-   , [ Infix (binaryOp "*") AssocLeft
-     , Infix (binaryOp "/") AssocLeft
-     , Infix (binaryOp "//") AssocLeft
-     , Infix (binaryOp "%") AssocLeft
-     ]
-   , [ Infix (binaryOp "+") AssocLeft
-     , Infix (binaryOp "-") AssocLeft
-     ]
-   , [ Infix consOp AssocRight ]
-   , [ Infix (binaryOp "++") AssocRight ]
-   , [ Infix (binaryOp "==") AssocNone
-     , Infix (binaryOp "/=") AssocNone
-     , Infix (binaryOp "<") AssocLeft
-     , Infix (binaryOp ">") AssocLeft
-     , Infix (binaryOp "<=") AssocLeft
-     , Infix (binaryOp ">=") AssocLeft
-     ]
-   , [ Infix (binaryOpIdent "and") AssocLeft ]
-   , [ Infix (binaryOpIdent "or") AssocLeft ]
-   , [ Infix infixFn AssocLeft ]
-   ]
+   opDefs
+      # groupBy (\a b -> a.prec == b.prec)
+      # sortBy (comparing (\grp -> negate (head grp).prec)) -- sort high -> low
+      # map (toArray <$> map toOperator)
+   where
+   toOperator :: OpDef -> Operator (StateT Position Identity) String (Raw Expr)
+   toOperator def = Infix (infixParser def.type def.op) def.assoc
+
+   infixParser :: OpType -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+   infixParser BinaryOp op = binaryOp op
+   infixParser BinaryId op = binaryOpIdent op
+   infixParser BinaryCons _ = consOp
+   infixParser CustomInfix _ = infixFn
 
 varDefs :: Parser (Raw VarDefs)
 varDefs = many1 varDef

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -23,15 +23,16 @@ import Parse.Number (float, integer)
 import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace)
 import Parsing (ParseError(..), Position(..), consume, fail, runParserT)
 import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
-import Parsing.Expr (Assoc(..), Operator(..), OperatorTable, buildExprParser)
+import Parsing.Expr (OperatorTable, buildExprParser)
+import Parsing.Expr (Assoc(..), Operator(..)) as P
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
-import Primitive.Parse (OpDef, OpType(..), opDefs)
+import Primitive.Parse (InfixParser(..), OpDef(..), opDefs, prec)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (+), type (×), nonEmpty, (×))
 
 pattern :: Parser Pattern
-pattern = defer \_ -> buildExprParser [ [ Infix pConsOp AssocRight ] ] simplePattern
+pattern = defer \_ -> buildExprParser [ [ P.Infix pConsOp P.AssocRight ] ] simplePattern
 
 simplePattern :: Parser Pattern
 simplePattern = pVar <|> pConstr <|> pRecord <|> pList <|> parensPattern
@@ -73,18 +74,18 @@ pConsOp = do
    reservedOperator ":|"
    pure \e e' -> PConstr ":" (e : e' : Nil)
 
-binaryOp :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-binaryOp op = do
+infixSymbol :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+infixSymbol op = do
    reservedOperator op
    pure \e e' -> BinaryApp e op e'
 
-binaryOpIdent :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-binaryOpIdent op = do
+infixIdent :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+infixIdent op = do
    reserved op
    pure \e e' -> BinaryApp e op e'
 
-infixFn :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
-infixFn = do
+infixCustom :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
+infixCustom = do
    fn <- try (delim '|' *> variable)
    delim '|'
    pure \e e' -> BinaryApp e fn e'
@@ -94,21 +95,21 @@ consOp = do
    reservedOperator ":|"
    pure \e e' -> Constr unit ":" (e : e' : Nil)
 
-binaryOps :: OperatorTable (StateT Position Identity) String (Raw Expr)
-binaryOps =
+opTable :: OperatorTable (StateT Position Identity) String (Raw Expr)
+opTable =
    opDefs
-      # groupBy (\a b -> a.prec == b.prec)
-      # sortBy (comparing (\grp -> negate (head grp).prec)) -- sort high -> low
+      # groupBy (\a b -> prec a == prec b)
+      # sortBy (comparing (\grp -> negate (prec (head grp)))) -- sort high -> low
       # map (toArray <$> map toOperator)
    where
-   toOperator :: OpDef -> Operator (StateT Position Identity) String (Raw Expr)
-   toOperator def = Infix (infixParser def.type def.op) def.assoc
+   toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
+   toOperator (Infix parser op assoc _) = P.Infix (infixParser parser op) assoc
 
-   infixParser :: OpType -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-   infixParser BinaryOp op = binaryOp op
-   infixParser BinaryId op = binaryOpIdent op
-   infixParser BinaryCons _ = consOp
-   infixParser CustomInfix _ = infixFn
+   infixParser :: InfixParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+   infixParser Symbol op = infixSymbol op
+   infixParser Ident op = infixIdent op
+   infixParser ConsOp _ = consOp
+   infixParser Custom _ = infixCustom
 
 varDefs :: Parser (Raw VarDefs)
 varDefs = many1 varDef
@@ -175,7 +176,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
       pure $ IfElse c t e
 
    opTree :: Parser (Raw Expr)
-   opTree = context "opTree" (buildExprParser binaryOps simpleChain) <* consume -- otherwise always `consume: false`
+   opTree = context "opTree" (buildExprParser opTable simpleChain) <* consume -- otherwise always `consume: false`
       where
 
       simpleChain :: Parser (Raw Expr)

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -16,7 +16,7 @@ import Expr as E
 import Lattice (class BotOf, class MeetSemilattice, class Neg, botOf, symmetricDiff)
 import Pretty.Doc (Doc, empty, expr, indent, inlOrMul, line, render, stmt, stmtOrExpr, text, (<++>), (<+>), (</>))
 import Pretty.Util (block, braces, brackets, hsep, matrix, number, pair, parens, record, sep', string, vsep)
-import Primitive.Parse (opMap)
+import Primitive.Parse (opMap, prec)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (×), isEmpty, (×))
 import Util.Map (toUnfoldable)
@@ -101,7 +101,7 @@ prettyP x = render (pretty x)
 
 getPrec :: String -> Int
 getPrec x = case lookup x opMap of
-   Just y -> y.prec
+   Just y -> prec y
    Nothing -> -1
 
 binaryApp :: forall a. Ann a => Int -> Expr a -> Doc

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -16,7 +16,7 @@ import Expr as E
 import Lattice (class BotOf, class MeetSemilattice, class Neg, botOf, symmetricDiff)
 import Pretty.Doc (Doc, empty, expr, indent, inlOrMul, line, render, stmt, stmtOrExpr, text, (<++>), (<+>), (</>))
 import Pretty.Util (block, braces, brackets, hsep, matrix, number, pair, parens, record, sep', string, vsep)
-import Primitive.Parse (opDefs)
+import Primitive.Parse (opMap)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (×), isEmpty, (×))
 import Util.Map (toUnfoldable)
@@ -100,7 +100,7 @@ prettyP :: forall a. Pretty a => a -> String
 prettyP x = render (pretty x)
 
 getPrec :: String -> Int
-getPrec x = case lookup x opDefs of
+getPrec x = case lookup x opMap of
    Just y -> y.prec
    Nothing -> -1
 

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -7,44 +7,42 @@ import Data.Map (Map, fromFoldable)
 import Parsing.Expr (Assoc(..))
 import Util ((×))
 
--- name in user land, precedence, associativity, type (for parser)
-type OpDef =
-   { op :: Var
-   , prec :: Int
-   , assoc :: Assoc
-   , type :: OpType
-   }
+data OpDef =
+   Infix InfixParser Var Assoc Int
 
-data OpType = BinaryOp | BinaryId | BinaryCons | CustomInfix
+data InfixParser = Symbol | Ident | ConsOp | Custom
 
-opDef :: Var -> Int -> Assoc -> OpType -> OpDef
-opDef op prec assoc ty = { op, prec, assoc, type: ty }
+name :: OpDef -> Var
+name (Infix _ n _ _) = n
+
+prec :: OpDef -> Int
+prec (Infix _ _ _ p) = p
 
 -- Aim to match Python operator precedence and associativty as defined in:
 -- https://docs.python.org/3/reference/expressions.html#operator-precedence
 opDefs :: Array OpDef
 opDefs =
-   [ opDef "!" 9 AssocLeft BinaryOp
-   , opDef "**" 8 AssocRight BinaryOp
-   , opDef "*" 7 AssocLeft BinaryOp
-   , opDef "/" 7 AssocLeft BinaryOp
-   , opDef "//" 7 AssocLeft BinaryOp
-   , opDef "%" 7 AssocLeft BinaryOp
-   , opDef "+" 6 AssocLeft BinaryOp
-   , opDef "-" 6 AssocLeft BinaryOp
-   , opDef ":" 5 AssocRight BinaryCons
-   , opDef "++" 4 AssocRight BinaryOp
-   , opDef "==" 3 AssocNone BinaryOp
-   , opDef "/=" 3 AssocNone BinaryOp
-   , opDef "<" 3 AssocLeft BinaryOp
-   , opDef ">" 3 AssocLeft BinaryOp
-   , opDef "<=" 3 AssocLeft BinaryOp
-   , opDef ">=" 3 AssocLeft BinaryOp
-   , opDef "and" 2 AssocLeft BinaryId
-   , opDef "or" 1 AssocLeft BinaryId
-   , opDef "|x|" 0 AssocLeft CustomInfix
+   [ Infix Symbol "!" AssocLeft 9
+   , Infix Symbol "**" AssocRight 8
+   , Infix Symbol "*" AssocLeft 7
+   , Infix Symbol "/" AssocLeft 7
+   , Infix Symbol "//" AssocLeft 7
+   , Infix Symbol "%" AssocLeft 7
+   , Infix Symbol "+" AssocLeft 6
+   , Infix Symbol "-" AssocLeft 6
+   , Infix ConsOp ":" AssocRight 5
+   , Infix Symbol "++" AssocRight 4
+   , Infix Symbol "==" AssocNone 3
+   , Infix Symbol "/=" AssocNone 3
+   , Infix Symbol "<" AssocLeft 3
+   , Infix Symbol ">" AssocLeft 3
+   , Infix Symbol "<=" AssocLeft 3
+   , Infix Symbol ">=" AssocLeft 3
+   , Infix Ident "and" AssocLeft 2
+   , Infix Ident "or" AssocLeft 1
+   , Infix Custom "|x|" AssocLeft 0
    ]
 
 -- for lookup by name
 opMap :: Map String OpDef
-opMap = fromFoldable $ map (\def -> def.op × def) opDefs
+opMap = fromFoldable $ map (\def -> name def × def) opDefs

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -1,40 +1,49 @@
 module Primitive.Parse where
 
+import Prelude
+
+import Bind (Var)
 import Data.Map (Map, fromFoldable)
 import Parsing.Expr (Assoc(..))
-import Bind (Var)
-import Util (type (×), (×))
+import Util ((×))
 
--- name in user land, precedence 0 from 9 (similar to Haskell 98), associativity
+-- name in user land, precedence, associativity, type (for parser)
 type OpDef =
    { op :: Var
    , prec :: Int
    , assoc :: Assoc
+   , type :: OpType
    }
 
-opDef :: Var -> Int -> Assoc -> Var × OpDef
-opDef op prec assoc = op × { op, prec, assoc }
+data OpType = BinaryOp | BinaryId | BinaryCons
 
--- Syntactic information only. No requirement that any of these be defined.
--- TODO: unify with defs in src/Parse.purs (this list is only used by pretty printer)
-opDefs :: Map String OpDef
-opDefs = fromFoldable
-   [ opDef "!" 9 AssocLeft
-   , opDef "**" 8 AssocRight
-   , opDef "*" 7 AssocLeft
-   , opDef "/" 7 AssocLeft
-   , opDef "//" 7 AssocLeft
-   , opDef "%" 7 AssocLeft
-   , opDef "+" 6 AssocLeft
-   , opDef "-" 6 AssocLeft
-   , opDef ":" 5 AssocRight
-   , opDef "++" 4 AssocRight
-   , opDef "==" 3 AssocNone
-   , opDef "/=" 3 AssocNone
-   , opDef "<" 3 AssocLeft
-   , opDef ">" 3 AssocLeft
-   , opDef "<=" 3 AssocLeft
-   , opDef ">=" 3 AssocLeft
-   , opDef "and" 2 AssocLeft
-   , opDef "or" 1 AssocLeft
+opDef :: Var -> Int -> Assoc -> OpType -> OpDef
+opDef op prec assoc ty = { op, prec, assoc, type: ty }
+
+-- Aim to match Python operator precedence and associativty as defined in:
+-- https://docs.python.org/3/reference/expressions.html#operator-precedence
+opDefs :: Array OpDef
+opDefs =
+   [ opDef "!" 9 AssocLeft BinaryOp
+   , opDef "**" 8 AssocRight BinaryOp
+   , opDef "*" 7 AssocLeft BinaryOp
+   , opDef "/" 7 AssocLeft BinaryOp
+   , opDef "//" 7 AssocLeft BinaryOp
+   , opDef "%" 7 AssocLeft BinaryOp
+   , opDef "+" 6 AssocLeft BinaryOp
+   , opDef "-" 6 AssocLeft BinaryOp
+   , opDef ":" 5 AssocRight BinaryCons
+   , opDef "++" 4 AssocRight BinaryOp
+   , opDef "==" 3 AssocNone BinaryOp
+   , opDef "/=" 3 AssocNone BinaryOp
+   , opDef "<" 3 AssocLeft BinaryOp
+   , opDef ">" 3 AssocLeft BinaryOp
+   , opDef "<=" 3 AssocLeft BinaryOp
+   , opDef ">=" 3 AssocLeft BinaryOp
+   , opDef "and" 2 AssocLeft BinaryId
+   , opDef "or" 1 AssocLeft BinaryId
    ]
+
+-- for lookup by name
+opMap :: Map String OpDef
+opMap = fromFoldable $ map (\def -> def.op × def) opDefs

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -19,8 +19,7 @@ opDef op prec assoc = op × { op, prec, assoc }
 -- TODO: unify with defs in src/Parse.purs (this list is only used by pretty printer)
 opDefs :: Map String OpDef
 opDefs = fromFoldable
-   [ opDef "." 8 AssocLeft
-   , opDef "!" 8 AssocLeft
+   [ opDef "!" 9 AssocLeft
    , opDef "**" 8 AssocRight
    , opDef "*" 7 AssocLeft
    , opDef "/" 7 AssocLeft
@@ -28,14 +27,14 @@ opDefs = fromFoldable
    , opDef "%" 7 AssocLeft
    , opDef "+" 6 AssocLeft
    , opDef "-" 6 AssocLeft
-   , opDef ":" 6 AssocRight
-   , opDef "++" 5 AssocRight
-   , opDef "==" 4 AssocNone
-   , opDef "/=" 4 AssocNone
-   , opDef "<" 4 AssocLeft
-   , opDef ">" 4 AssocLeft
-   , opDef "<=" 4 AssocLeft
-   , opDef ">=" 4 AssocLeft
-   , opDef "and" 3 AssocLeft
-   , opDef "or" 2 AssocLeft
+   , opDef ":" 5 AssocRight
+   , opDef "++" 4 AssocRight
+   , opDef "==" 3 AssocNone
+   , opDef "/=" 3 AssocNone
+   , opDef "<" 3 AssocLeft
+   , opDef ">" 3 AssocLeft
+   , opDef "<=" 3 AssocLeft
+   , opDef ">=" 3 AssocLeft
+   , opDef "and" 2 AssocLeft
+   , opDef "or" 1 AssocLeft
    ]

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -15,7 +15,7 @@ type OpDef =
    , type :: OpType
    }
 
-data OpType = BinaryOp | BinaryId | BinaryCons
+data OpType = BinaryOp | BinaryId | BinaryCons | CustomInfix
 
 opDef :: Var -> Int -> Assoc -> OpType -> OpDef
 opDef op prec assoc ty = { op, prec, assoc, type: ty }
@@ -42,6 +42,7 @@ opDefs =
    , opDef ">=" 3 AssocLeft BinaryOp
    , opDef "and" 2 AssocLeft BinaryId
    , opDef "or" 1 AssocLeft BinaryId
+   , opDef "|x|" 0 AssocLeft CustomInfix
    ]
 
 -- for lookup by name


### PR DESCRIPTION
After migrating to the new syntax we had two separate operator tables used separately by the parser and pretty printer.

This PR has both using the same operator table, which contains additional information to direct parsing, and reorganises to support future work including: Python-compatible precedence, prefix/postfix operators, possibility for projection/app/ternary to be defined in the table.

This should be a pure refactor with no effect on behaviour.