### PR TITLE
Python-compatible precedence for custom infix functions (`|fn|`)  

### DIFF
--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -107,7 +107,9 @@ getPrec x = case lookup x opMap of
 binaryApp :: forall a. Ann a => Int -> Expr a -> Doc
 binaryApp n (BinaryApp s op s') =
    case getPrec op of
-      -1 -> binaryApp 0 s <+> text "|" <> text op <> text "|" <+> binaryApp 0 s'
+      -1 -> binaryApp customPrec s <+> text "|" <> text op <> text "|" <+> binaryApp customPrec s'
+         where
+         customPrec = getPrec "|x|"
       n' ->
          if n' <= n then
             parens (binaryApp n' s <+> text op <+> binaryApp n' s')

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -32,15 +32,15 @@ opDefs =
    , Infix Symbol "-" AssocLeft 6
    , Infix ConsOp ":" AssocRight 5
    , Infix Symbol "++" AssocRight 4
-   , Infix Symbol "==" AssocNone 3
-   , Infix Symbol "/=" AssocNone 3
-   , Infix Symbol "<" AssocLeft 3
-   , Infix Symbol ">" AssocLeft 3
-   , Infix Symbol "<=" AssocLeft 3
-   , Infix Symbol ">=" AssocLeft 3
-   , Infix Ident "and" AssocLeft 2
-   , Infix Ident "or" AssocLeft 1
-   , Infix Custom "|x|" AssocLeft 0
+   , Infix Custom "|x|" AssocLeft 3
+   , Infix Symbol "==" AssocNone 2
+   , Infix Symbol "/=" AssocNone 2
+   , Infix Symbol "<" AssocLeft 2
+   , Infix Symbol ">" AssocLeft 2
+   , Infix Symbol "<=" AssocLeft 2
+   , Infix Symbol ">=" AssocLeft 2
+   , Infix Ident "and" AssocLeft 1
+   , Infix Ident "or" AssocLeft 0
    ]
 
 -- for lookup by name

--- a/test/Specs/Misc.purs
+++ b/test/Specs/Misc.purs
@@ -8,6 +8,7 @@ misc_cases =
    , { file: "array.fld", fwd_expect: "(1, (3, 3))" }
    , { file: "boolean-precedence.fld", fwd_expect: "True" }
    , { file: "compose.fld", fwd_expect: "5" }
+   , { file: "custom-infix.fld", fwd_expect: "True" }
    , { file: "dicts.fld"
      , fwd_expect: "{ d: {}, e: { a: 5, ab: 6 }, e_ab: 6, f: { a: 6, ab: 7 }, g: { a: 5 } }"
      }

--- a/test/fluid/custom-infix.fld
+++ b/test/fluid/custom-infix.fld
@@ -1,0 +1,7 @@
+def mult(x,y): x * y
+
+# `|x|` binds tighter than `and` and `==`, but less than `+`, so the
+# following is equivalent to `True and (((1 + 2) |mult| 3) == 9)` (`True`).
+# If it bound less tightly than `and`, this would be a type error.
+# If it bound tighter than `+` then this would be `False`.
+True and 1 + 2 |mult| 3 == 9


### PR DESCRIPTION
Puts the precedence level somewhere between arithmetic and boolean comparison to match Python's `|` operator.

The changes to `getPrec` in `Pretty.purs` are a little hacky but this is likely to be expanded / developed later.