### PR TITLE
Multiple clauses in `SExpr.IfElse`, parsing `elifs`

### DIFF
--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -175,20 +175,17 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
          pure $ Let ds e
 
    ifElse :: Parser (Raw Expr)
-   ifElse = reserved "if" *> cte
+   ifElse = do
+      reserved "if"
+      c <- clause
+      cs <- many (align $ reserved "elif" *> clause)
+      e <- align $ reserved "else" *> block expr
+      pure $ IfElse (nonEmpty (c : cs)) e
       where
-      cte = do
+      clause = do
          c <- opTree
-         t <- block expr
-         e <- choice
-            [ do
-                 align $ reserved "elif"
-                 cte
-            , do
-                 align $ reserved "else"
-                 block expr
-            ]
-         pure $ IfElse c t e
+         e <- block expr
+         pure (c × e)
 
    opTree :: Parser (Raw Expr)
    opTree = context "opTree" (buildExprParser binaryOps simpleChain) <* consume -- otherwise always `consume: false`

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -175,13 +175,20 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
          pure $ Let ds e
 
    ifElse :: Parser (Raw Expr)
-   ifElse = do
-      reserved "if"
-      c <- opTree
-      t <- block expr
-      align $ reserved "else"
-      e <- block expr
-      pure $ IfElse c t e
+   ifElse = reserved "if" *> cte
+      where
+      cte = do
+         c <- opTree
+         t <- block expr
+         e <- choice
+            [ do
+                 align $ reserved "elif"
+                 cte
+            , do
+                 align $ reserved "else"
+                 block expr
+            ]
+         pure $ IfElse c t e
 
    opTree :: Parser (Raw Expr)
    opTree = context "opTree" (buildExprParser binaryOps simpleChain) <* consume -- otherwise always `consume: false`

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -4,10 +4,11 @@ import Prelude
 
 import Bind (Bind, Var, (↦))
 import Data.List (List(..), fromFoldable, singleton, (:))
-import Data.List.NonEmpty (NonEmptyList, head, toList)
+import Data.List.NonEmpty (NonEmptyList(..), head, toList)
 import Data.Map (lookup)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
+import Data.NonEmpty ((:|))
 import Data.Traversable (class Foldable)
 import DataType (Ctr, cCons)
 import Dict (Dict)
@@ -70,7 +71,7 @@ instance Ann a => IsSimple (Expr a) where
    isSimple (Lambda _) = false
    isSimple (Let _ _) = false
    isSimple (LetRec _ _) = false
-   isSimple (IfElse _ _ _) = false
+   isSimple (IfElse _ _) = false
    isSimple (MatchAs _ _) = false
    isSimple _ = true
 
@@ -136,8 +137,12 @@ instance Ann a => Pretty (Expr a) where
    pretty (App s s') = expr $ prettyAppChain (App s s') Nil
    pretty (BinaryApp s op s') = expr $ binaryApp 0 (BinaryApp s op s')
    pretty (MatchAs s cs) = text "match" <+> pretty s <> block (pretty cs)
-   pretty (IfElse i t e) =
-      text "if" <+> expr (pretty i) <> block (pretty t) <++> text "else" <> block (pretty e)
+   pretty (IfElse (NonEmptyList (ss :| sss)) e) =
+      vsep (prettyClause "if" ss : (prettyClause "elif" <$> sss))
+         <++> text "else" <> block (pretty e)
+      where
+      prettyClause w (s × s') = text w <+> expr (pretty s) <> block (pretty s')
+
    pretty (ListEmpty α) = highlightIf α (text "[]")
    pretty (ListNonEmpty α e rest) =
       highlightIf α (text "[")

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -12,7 +12,7 @@ import Data.Foldable (length)
 import Data.Function (on)
 import Data.Generic.Rep (class Generic)
 import Data.List (List(..), drop, take, unzip, zip, zipWith, (:), (\\))
-import Data.List.NonEmpty (NonEmptyList(..), groupBy, head, toList, unsnoc)
+import Data.List.NonEmpty (NonEmptyList(..), foldr, groupBy, head, toList, unsnoc)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype, unwrap)
 import Data.NonEmpty ((:|))
@@ -52,7 +52,7 @@ data Expr a
    | App (Expr a) (Expr a)
    | BinaryApp (Expr a) Var (Expr a)
    | MatchAs (Expr a) (NonEmptyList (Pattern × Expr a))
-   | IfElse (Expr a) (Expr a) (Expr a)
+   | IfElse (NonEmptyList (Expr a × Expr a)) (Expr a)
    | Paragraph (Paragraph a)
    | ListEmpty a
    | ListNonEmpty a (Expr a) (ListRest a)
@@ -314,10 +314,8 @@ exprFwd (BinaryApp s1 op s2) =
    E.App <$> (E.App (E.Op op) <$> desug s1) <*> desug s2
 exprFwd (MatchAs s μ) =
    E.App <$> (E.Lambda top <$> desug (Clauses (Clause <$> first singleton <$> μ))) <*> desug s
-exprFwd (IfElse s1 s2 s3) =
-   E.App
-      <$> (E.Lambda top <$> (elimBool <$> (ContExpr <$> desug s2) <*> (ContExpr <$> desug s3)))
-      <*> desug s1
+exprFwd (IfElse sss s) =
+   ifElseFwd (sss × s)
 exprFwd (Paragraph elems) =
    paragraphFwd elems
 exprFwd (ListEmpty α) =
@@ -364,10 +362,8 @@ exprBwd (E.App (E.App (E.Op _) e1) e2) (BinaryApp s1 op s2) =
 exprBwd (E.App (E.Lambda _ σ) e) (MatchAs s μ) =
    MatchAs (desugBwd e s)
       (first head <$> unwrap <$> unwrap (desugBwd σ (Clauses (Clause <$> first singleton <$> μ))))
-exprBwd (E.App (E.Lambda _ (ElimConstr m)) e1) (IfElse s1 s2 s3) =
-   IfElse (desugBwd e1 s1)
-      (if cTrue ∈ m then desugBwd (asExpr (get cTrue m)) s2 else botOf s2)
-      (if cFalse ∈ m then desugBwd (asExpr (get cFalse m)) s3 else botOf s3)
+exprBwd e@(E.App (E.Lambda _ (ElimConstr _)) _) (IfElse sss s) =
+   let sss' × s' = ifElseBwd e (sss × s) in IfElse sss' s'
 exprBwd (E.Constr _ c (es : Nil)) (Paragraph elems) | c == cParagraph =
    Paragraph (paragraphElemsBwd es elems)
 exprBwd (E.Constr α _ Nil) (ListEmpty _) =
@@ -387,6 +383,32 @@ exprBwd (E.LetRec xσs e) (LetRec xcs s) =
 exprBwd (E.DocExpr e e') (DocExpr s s') =
    DocExpr (exprBwd e s) (exprBwd e' s')
 exprBwd _ s = error $ "ExprBwd failed, s: " <> show s
+
+type IfElseClauses a = NonEmptyList (Expr a × Expr a) × Expr a
+
+ifElseFwd :: forall a m. BoundedLattice a => MonadError Error m => IfElseClauses a -> m (E.Expr a)
+ifElseFwd (sss × s) =
+   foldr clause (desug s) sss
+   where
+   clause (s1 × s2) e3 =
+      E.App
+         <$> (E.Lambda top <$> (elimBool <$> (ContExpr <$> desug s2) <*> (ContExpr <$> e3)))
+         <*> desug s1
+
+ifElseBwd :: forall a. BoundedJoinSemilattice a => E.Expr a -> Raw IfElseClauses -> IfElseClauses a
+ifElseBwd (E.App (E.Lambda _ (ElimConstr m)) e1) (NonEmptyList (s1 × s2 :| sss) × s) =
+   let
+      ss' = desugBwd e1 s1 × bwdWhen cTrue s2
+      sss' × s' = case sss of
+         Nil -> Nil × bwdWhen cFalse s
+         _ -> case bwdWhen cFalse (IfElse (nonEmpty sss) s) of
+            IfElse sss' s' -> toList sss' × s'
+            _ -> error absurd
+   in
+      nonEmpty (ss' : sss') × s'
+   where
+   bwdWhen c = if c ∈ m then desugBwd (asExpr (get c m)) else botOf
+ifElseBwd _ _ = error absurd
 
 -- List Qualifier × Expr
 listCompFwd :: forall a m. MonadError Error m => BoundedLattice a => a × List (Qualifier a) × Expr a -> m (E.Expr a)

--- a/test/Specs/Misc.purs
+++ b/test/Specs/Misc.purs
@@ -18,6 +18,7 @@ misc_cases =
           \(1 :| -1 :| -1 :| 1 :| []) :| \
           \(2 :| 2 :| -2 :| -2 :| []) :| []"
      }
+   , { file: "elif.fld", fwd_expect: """"much more" :| "more" :| "less" :| "much less" :| []""" }
    , { file: "factorial.fld", fwd_expect: "40320" }
    , { file: "filter.fld", fwd_expect: "8 :| 7 :| []" }
    , { file: "first-class-constr.fld", fwd_expect: "(10 :| []) :| (12 :| []) :| (20 :| []) :| []" }

--- a/test/fluid/elif.fld
+++ b/test/fluid/elif.fld
@@ -1,0 +1,13 @@
+def graded_leq_p(n, m):
+  def ratio: n / m
+  if ratio <= 0.5: "much less"
+  elif ratio <= 1.0: "less"
+  elif ratio <= 2.0: "more"
+  else: "much more"
+
+[
+    graded_leq_p(3, 1),
+    graded_leq_p(3, 2),
+    graded_leq_p(2, 3),
+    graded_leq_p(1, 3),
+]


### PR DESCRIPTION
Changes `IfElse` in `SExpr` to support multiple clauses and parser updated to parse `elif` blocks.

Resolves #1468