### PR TITLE
Unary not and prepare operator table for wider handling

### DIFF
--- a/packages.dhall
+++ b/packages.dhall
@@ -91,7 +91,7 @@ let upstream =
       https://github.com/purescript/package-sets/releases/download/psc-0.15.10-20231023/packages.dhall
         sha256:b9a482e743055ba8f2d65b08a88cd772b59c6e2084d0e5ad854025fa90417fd4
 
-let overrides = { parsing = upstream.parsing // { version = "v10.3.1" } }
+let overrides = { parsing = upstream.parsing // { version = "v11.0.0" } }
 
 let additions =
       { toppokki =

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -89,6 +89,11 @@ infixCustom = do
    delim '|'
    pure \e e' -> BinaryApp e fn e'
 
+prefixIdent :: String -> Parser (Raw Expr -> Raw Expr)
+prefixIdent op = do
+   reserved op
+   pure \e -> App (Var op) e
+
 consOp :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
 consOp = do
    reservedOperator ":|"
@@ -100,7 +105,7 @@ opTable =
    where
    toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
    toOperator (Infix parser op assoc) = P.Infix (infixParser parser op) assoc
-   toOperator (Prefix _ _) = error "not implemented!"
+   toOperator (Prefix parser op) = P.Prefix (prefixParser parser op)
    toOperator (Postfix _ _) = error "not implemented!"
 
    infixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
@@ -108,6 +113,10 @@ opTable =
    infixParser Ident op = infixIdent op
    infixParser ConsOp _ = consOp
    infixParser Custom _ = infixCustom
+
+   prefixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr)
+   prefixParser Ident op = prefixIdent op
+   prefixParser _ _ = error "not implemented!"
 
 varDefs :: Parser (Raw VarDefs)
 varDefs = many1 varDef

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -101,7 +101,7 @@ opTable =
    binaryApp p = p <#> \op e e' -> BinaryApp e op e'
 
    unaryPrefixApp :: Parser String -> Parser (Raw Expr -> Raw Expr)
-   unaryPrefixApp p = p <#> \op e -> App (Var op) e
+   unaryPrefixApp p = p <#> \op e -> UnaryPrefixApp op e
 
    symbol :: String -> Parser String
    symbol s = reservedOperator s $> s

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -26,7 +26,7 @@ import Parsing.Expr (Assoc(..), Operator(..)) as P
 import Parsing.Expr (Assoc(..), OperatorTable, buildExprParser)
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
-import Primitive.Parse (OpDef(..), Op(..), Fixity(..), opDefs)
+import Primitive.Parse (OpDef(..), OpType(..), Fixity(..), opDefs)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (+), type (×), error, nonEmpty, (×))
 
@@ -150,9 +150,9 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
          opDefs # map (map toOperator)
          where
          toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
-         toOperator (OpDef id t) = case t of
-            Symbol fix -> op fix (reservedOperator id $> id)
-            Ident fix -> op fix (reserved id $> id)
+         toOperator (OpDef id fix opType) = case opType of
+            Symbol -> op fix (reservedOperator id $> id)
+            Ident -> op fix (reserved id $> id)
             CustomOp -> op (Infix AssocLeft) (try (delim '|' *> variable) <* delim '|')
             ConsOp -> P.Infix consOp AssocRight
             ProjectOp -> error "not implemented!"

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -23,10 +23,10 @@ import Parse.Parser (Parser, align, block, braces, brackets, close, commas, comm
 import Parsing (ParseError(..), Position(..), consume, fail, runParserT)
 import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
 import Parsing.Expr (Assoc(..), Operator(..)) as P
-import Parsing.Expr (OperatorTable, buildExprParser)
+import Parsing.Expr (Assoc(..), OperatorTable, buildExprParser)
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
-import Primitive.Parse (OpDef(..), OpParser(..), opDefs)
+import Primitive.Parse (OpDef(..), Op(..), Fixity(..), opDefs)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (+), type (×), error, nonEmpty, (×))
 
@@ -72,45 +72,6 @@ pConsOp :: Parser (Pattern -> Pattern -> Pattern)
 pConsOp = do
    reservedOperator ":|"
    pure \e e' -> PConstr ":" (e : e' : Nil)
-
-consOp :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
-consOp = do
-   reservedOperator ":|"
-   pure \e e' -> Constr unit ":" (e : e' : Nil)
-
-opTable :: OperatorTable (StateT Position Identity) String (Raw Expr)
-opTable =
-   opDefs # map (map toOperator)
-   where
-   toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
-   toOperator (Infix parser op assoc) = P.Infix (infixParser parser op) assoc
-   toOperator (Prefix parser op) = P.Prefix (prefixParser parser op)
-   toOperator (Postfix _ _) = error "not implemented!"
-
-   infixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-   infixParser Symbol op = binaryApp (symbol op)
-   infixParser Ident op = binaryApp (ident op)
-   infixParser ConsOp _ = consOp
-   infixParser Custom _ = binaryApp custom
-
-   prefixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr)
-   prefixParser Ident op = unaryPrefixApp (ident op)
-   prefixParser _ _ = error "not implemented!"
-
-   binaryApp :: Parser String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-   binaryApp p = p <#> \op e e' -> BinaryApp e op e'
-
-   unaryPrefixApp :: Parser String -> Parser (Raw Expr -> Raw Expr)
-   unaryPrefixApp p = p <#> \op e -> UnaryPrefixApp op e
-
-   symbol :: String -> Parser String
-   symbol s = reservedOperator s $> s
-
-   ident :: String -> Parser String
-   ident s = reserved s $> s
-
-   custom :: Parser String
-   custom = try (delim '|' *> variable) <* delim '|'
 
 varDefs :: Parser (Raw VarDefs)
 varDefs = many1 varDef
@@ -183,6 +144,29 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
    opTree :: Parser (Raw Expr)
    opTree = context "opTree" (buildExprParser opTable simpleChain) <* consume -- otherwise always `consume: false`
       where
+
+      opTable :: OperatorTable (StateT Position Identity) String (Raw Expr)
+      opTable =
+         opDefs # map (map toOperator)
+         where
+         toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
+         toOperator (OpDef id t) = case t of
+            Symbol fix -> op fix (reservedOperator id $> id)
+            Ident fix -> op fix (reserved id $> id)
+            CustomOp -> op (Infix AssocLeft) (try (delim '|' *> variable) <* delim '|')
+            ConsOp -> P.Infix consOp AssocRight
+            ProjectOp -> error "not implemented!"
+
+         op :: Fixity -> Parser String -> P.Operator (StateT Position Identity) String (Raw Expr)
+         op fix p = case fix of
+            Infix assoc -> P.Infix (p <#> \id e e' -> BinaryApp e id e') assoc
+            Prefix -> P.Prefix (p <#> \id e -> UnaryPrefixApp id e)
+            Postfix -> error "not implemented!"
+
+         consOp :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
+         consOp = do
+            reservedOperator ":|"
+            pure \e e' -> Constr unit ":" (e : e' : Nil)
 
       simpleChain :: Parser (Raw Expr)
       simpleChain = withPos (simple >>= chain)

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -73,27 +73,6 @@ pConsOp = do
    reservedOperator ":|"
    pure \e e' -> PConstr ":" (e : e' : Nil)
 
-infixSymbol :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-infixSymbol op = do
-   reservedOperator op
-   pure \e e' -> BinaryApp e op e'
-
-infixIdent :: String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-infixIdent op = do
-   reserved op
-   pure \e e' -> BinaryApp e op e'
-
-infixCustom :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
-infixCustom = do
-   fn <- try (delim '|' *> variable)
-   delim '|'
-   pure \e e' -> BinaryApp e fn e'
-
-prefixIdent :: String -> Parser (Raw Expr -> Raw Expr)
-prefixIdent op = do
-   reserved op
-   pure \e -> App (Var op) e
-
 consOp :: Parser (Raw Expr -> Raw Expr -> Raw Expr)
 consOp = do
    reservedOperator ":|"
@@ -109,14 +88,29 @@ opTable =
    toOperator (Postfix _ _) = error "not implemented!"
 
    infixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
-   infixParser Symbol op = infixSymbol op
-   infixParser Ident op = infixIdent op
+   infixParser Symbol op = binaryApp (symbol op)
+   infixParser Ident op = binaryApp (ident op)
    infixParser ConsOp _ = consOp
-   infixParser Custom _ = infixCustom
+   infixParser Custom _ = binaryApp custom
 
    prefixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr)
-   prefixParser Ident op = prefixIdent op
+   prefixParser Ident op = unaryPrefixApp (ident op)
    prefixParser _ _ = error "not implemented!"
+
+   binaryApp :: Parser String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+   binaryApp p = p <#> \op e e' -> BinaryApp e op e'
+
+   unaryPrefixApp :: Parser String -> Parser (Raw Expr -> Raw Expr)
+   unaryPrefixApp p = p <#> \op e -> App (Var op) e
+
+   symbol :: String -> Parser String
+   symbol s = reservedOperator s $> s
+
+   ident :: String -> Parser String
+   ident s = reserved s $> s
+
+   custom :: Parser String
+   custom = try (delim '|' *> variable) <* delim '|'
 
 varDefs :: Parser (Raw VarDefs)
 varDefs = many1 varDef

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -22,13 +22,13 @@ import Parse.Number (float, integer)
 import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace)
 import Parsing (ParseError(..), Position(..), consume, fail, runParserT)
 import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
-import Parsing.Expr (OperatorTable, buildExprParser)
 import Parsing.Expr (Assoc(..), Operator(..)) as P
+import Parsing.Expr (OperatorTable, buildExprParser)
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
-import Primitive.Parse (InfixParser(..), OpDef(..), opDefs)
+import Primitive.Parse (OpDef(..), OpParser(..), opDefs)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
-import Util (type (+), type (×), nonEmpty, (×))
+import Util (type (+), type (×), error, nonEmpty, (×))
 
 pattern :: Parser Pattern
 pattern = defer \_ -> buildExprParser [ [ P.Infix pConsOp P.AssocRight ] ] simplePattern
@@ -100,8 +100,10 @@ opTable =
    where
    toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
    toOperator (Infix parser op assoc) = P.Infix (infixParser parser op) assoc
+   toOperator (Prefix _ _) = error "not implemented!"
+   toOperator (Postfix _ _) = error "not implemented!"
 
-   infixParser :: InfixParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
+   infixParser :: OpParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
    infixParser Symbol op = infixSymbol op
    infixParser Ident op = infixIdent op
    infixParser ConsOp _ = consOp

--- a/src/Parse.purs
+++ b/src/Parse.purs
@@ -5,8 +5,7 @@ import Prelude
 import Control.Alt ((<|>))
 import Control.Lazy (defer)
 import Control.Monad.State (StateT)
-import Data.Array (fromFoldable, groupBy, some, sortBy)
-import Data.Array.NonEmpty (head, toArray)
+import Data.Array (fromFoldable, some)
 import Data.Bifunctor (lmap)
 import Data.CodePoint.Unicode (isSpace)
 import Data.Either (Either, choose)
@@ -27,7 +26,7 @@ import Parsing.Expr (OperatorTable, buildExprParser)
 import Parsing.Expr (Assoc(..), Operator(..)) as P
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
-import Primitive.Parse (InfixParser(..), OpDef(..), opDefs, prec)
+import Primitive.Parse (InfixParser(..), OpDef(..), opDefs)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (+), type (×), nonEmpty, (×))
 
@@ -97,13 +96,10 @@ consOp = do
 
 opTable :: OperatorTable (StateT Position Identity) String (Raw Expr)
 opTable =
-   opDefs
-      # groupBy (\a b -> prec a == prec b)
-      # sortBy (comparing (\grp -> negate (prec (head grp)))) -- sort high -> low
-      # map (toArray <$> map toOperator)
+   opDefs # map (map toOperator)
    where
    toOperator :: OpDef -> P.Operator (StateT Position Identity) String (Raw Expr)
-   toOperator (Infix parser op assoc _) = P.Infix (infixParser parser op) assoc
+   toOperator (Infix parser op assoc) = P.Infix (infixParser parser op) assoc
 
    infixParser :: InfixParser -> String -> Parser (Raw Expr -> Raw Expr -> Raw Expr)
    infixParser Symbol op = infixSymbol op

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -18,7 +18,7 @@ import Pretty.Doc (Doc, empty, expr, indent, inlOrMul, line, render, stmt, stmtO
 import Pretty.Util (block, braces, brackets, hsep, matrix, number, pair, parens, record, sep', string, vsep)
 import Primitive.Parse (getPrec)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
-import Util (type (×), isEmpty, (×))
+import Util (type (×), error, isEmpty, (×))
 import Util.Map (toUnfoldable)
 import Util.Pair (Pair(..))
 import Val (BaseVal(..), Fun(..)) as V
@@ -47,6 +47,7 @@ instance RootOp Pattern where
 instance Ann a => RootOp (Expr a) where
    rootOp (Constr _ c _) | c == cCons = Just ":"
    rootOp (BinaryApp _ op _) = Just op
+   rootOp (UnaryPrefixApp op _) = Just op
    rootOp _ = Nothing
 
 instance Highlightable a => RootOp (E.Expr a) where
@@ -66,6 +67,7 @@ class IsSimple (e :: Type) where
 
 instance Ann a => IsSimple (Expr a) where
    isSimple (BinaryApp _ _ _) = false
+   isSimple (UnaryPrefixApp _ _) = false
    isSimple (Constr _ c _) | c == cCons = false
    isSimple (Lambda _) = false
    isSimple (Let _ _) = false
@@ -99,18 +101,26 @@ prettySimple s =
 prettyP :: forall a. Pretty a => a -> String
 prettyP x = render (pretty x)
 
-binaryApp :: forall a. Ann a => Int -> Expr a -> Doc
-binaryApp n (BinaryApp s op s') =
+operatorApp :: forall a. Ann a => Int -> Expr a -> Doc
+operatorApp n (BinaryApp s op s') =
    case getPrec op of
-      -1 -> binaryApp customPrec s <+> text "|" <> text op <> text "|" <+> binaryApp customPrec s'
+      -1 -> operatorApp customPrec s <+> text "|" <> text op <> text "|" <+> operatorApp customPrec s'
          where
          customPrec = getPrec "|x|"
       n' ->
          if n' <= n then
-            parens (binaryApp n' s <+> text op <+> binaryApp n' s')
+            parens (operatorApp n' s <+> text op <+> operatorApp n' s')
          else
-            binaryApp n' s <+> text op <+> binaryApp n' s'
-binaryApp _ e = prettySimple e
+            operatorApp n' s <+> text op <+> operatorApp n' s'
+operatorApp n (UnaryPrefixApp op s) =
+   case getPrec op of
+      -1 -> error "not implemented!"
+      n' ->
+         if n' <= n then
+            parens (text op <+> operatorApp n' s)
+         else
+            text op <+> operatorApp n' s
+operatorApp _ e = prettySimple e
 
 lambda :: forall a. Ann a => List Pattern -> Expr a -> Doc
 lambda ps e = text "lambda" <+> prettyList ps <> text ":" <+> pretty e
@@ -131,7 +141,8 @@ instance Ann a => Pretty (Expr a) where
    pretty (Project s x) = expr $ prettySimple s <> text "." <> text x
    pretty (DProject e k) = expr $ prettySimple e <> brackets (expr $ pretty k)
    pretty (App s s') = expr $ prettyAppChain (App s s') Nil
-   pretty (BinaryApp s op s') = expr $ binaryApp 0 (BinaryApp s op s')
+   pretty (BinaryApp s op s') = expr $ operatorApp 0 (BinaryApp s op s')
+   pretty (UnaryPrefixApp op s) = expr $ operatorApp 0 (UnaryPrefixApp op s)
    pretty (MatchAs s cs) = text "match" <+> pretty s <> block (pretty cs)
    pretty (IfElse (NonEmptyList (ss :| sss)) e) =
       vsep (prettyClause "if" ss : (prettyClause "elif" <$> sss))

--- a/src/Pretty.purs
+++ b/src/Pretty.purs
@@ -5,7 +5,6 @@ import Prelude
 import Bind (Bind, Var, (↦))
 import Data.List (List(..), fromFoldable, singleton, (:))
 import Data.List.NonEmpty (NonEmptyList(..), head, toList)
-import Data.Map (lookup)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (class Newtype)
 import Data.NonEmpty ((:|))
@@ -17,7 +16,7 @@ import Expr as E
 import Lattice (class BotOf, class MeetSemilattice, class Neg, botOf, symmetricDiff)
 import Pretty.Doc (Doc, empty, expr, indent, inlOrMul, line, render, stmt, stmtOrExpr, text, (<++>), (<+>), (</>))
 import Pretty.Util (block, braces, brackets, hsep, matrix, number, pair, parens, record, sep', string, vsep)
-import Primitive.Parse (opMap, prec)
+import Primitive.Parse (getPrec)
 import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
 import Util (type (×), isEmpty, (×))
 import Util.Map (toUnfoldable)
@@ -99,11 +98,6 @@ prettySimple s =
 
 prettyP :: forall a. Pretty a => a -> String
 prettyP x = render (pretty x)
-
-getPrec :: String -> Int
-getPrec x = case lookup x opMap of
-   Just y -> prec y
-   Nothing -> -1
 
 binaryApp :: forall a. Ann a => Int -> Expr a -> Doc
 binaryApp n (BinaryApp s op s') =

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -8,18 +8,18 @@ import Data.Maybe (Maybe(..))
 import Parsing.Expr (Assoc(..))
 import Util ((×))
 
-data OpDef = OpDef String Op
+data OpDef = OpDef String Fixity OpType
 
-data Op
-   = Symbol Fixity
-   | Ident Fixity
+data OpType
+   = Symbol
+   | Ident
    | CustomOp
    | ConsOp
    | ProjectOp
 
 data Fixity = Infix Assoc | Prefix | Postfix
 
-op :: String -> Op -> OpDef
+op :: String -> Fixity -> OpType -> OpDef
 op = OpDef
 
 -- Aim to match Python operator precedence and associativty as defined in:
@@ -27,55 +27,46 @@ op = OpDef
 opDefs :: Array (Array OpDef)
 opDefs =
    -- Matrix lookup
-   [ [ op "!" symbol ]
+   [ [ op "!" (Infix AssocLeft) Symbol ]
    -- Exponentiation
-   , [ op "**" symbolR ]
+   , [ op "**" (Infix AssocRight) Symbol ]
    -- Multiplication, division, floor division, remainder
-   , [ op "*" symbol
-     , op "/" symbol
-     , op "//" symbol
-     , op "%" symbol
+   , [ op "*" (Infix AssocLeft) Symbol
+     , op "/" (Infix AssocLeft) Symbol
+     , op "//" (Infix AssocLeft) Symbol
+     , op "%" (Infix AssocLeft) Symbol
      ]
    -- Addition and subtraction
-   , [ op "+" symbol
-     , op "-" symbol
+   , [ op "+" (Infix AssocLeft) Symbol
+     , op "-" (Infix AssocLeft) Symbol
      ]
    -- Cons
-   , [ op ":" ConsOp ]
+   , [ op ":" (Infix AssocLeft) ConsOp ]
    -- String concat
-   , [ op "++" symbolR ]
+   , [ op "++" (Infix AssocRight) Symbol ]
    -- Custom operators (as Python's bitwise OR)
-   , [ op "|x|" CustomOp ]
+   , [ op "|x|" (Infix AssocLeft) CustomOp ]
    -- Comparisons, including membership tests and identity tests
-   , [ op "==" symbolN
-     , op "/=" symbolN
-     , op "<" symbol
-     , op ">" symbol
-     , op "<=" symbol
-     , op ">=" symbol
+   , [ op "==" (Infix AssocNone) Symbol
+     , op "/=" (Infix AssocNone) Symbol
+     , op "<" (Infix AssocLeft) Symbol
+     , op ">" (Infix AssocLeft) Symbol
+     , op "<=" (Infix AssocLeft) Symbol
+     , op ">=" (Infix AssocLeft) Symbol
      ]
    -- Boolean NOT
-   , [ op "not" identPrefix ]
+   , [ op "not" Prefix Ident ]
    -- Boolean AND
-   , [ op "and" ident ]
+   , [ op "and" (Infix AssocLeft) Ident ]
    -- Boolean OR
-   , [ op "or" ident ]
+   , [ op "or" (Infix AssocLeft) Ident ]
    ]
-
-   where
-
-   symbol = Symbol (Infix AssocLeft)
-   symbolR = Symbol (Infix AssocRight)
-   symbolN = Symbol (Infix AssocNone)
-
-   ident = Ident (Infix AssocLeft)
-   identPrefix = Ident Prefix
 
 -- name -> prec
 opPrecs :: Map String Int
 opPrecs = fromFoldable do
    i × ops <- mapWithIndex (×) opDefs
-   (OpDef name _) <- ops
+   (OpDef name _ _) <- ops
    pure $ name × (length opDefs - i) -- table is high-low
 
 getPrec :: String -> Int

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -45,6 +45,7 @@ opDefs =
      , Infix Symbol "<=" AssocLeft
      , Infix Symbol ">=" AssocLeft
      ]
+   , [ Prefix Ident "not" ]
    , [ Infix Ident "and" AssocLeft ]
    , [ Infix Ident "or" AssocLeft ]
    ]

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -9,13 +9,17 @@ import Data.Maybe (Maybe(..))
 import Parsing.Expr (Assoc(..))
 import Util ((×))
 
-data OpDef =
-   Infix InfixParser Var Assoc
+data OpDef
+   = Infix OpParser Var Assoc
+   | Prefix OpParser Var
+   | Postfix OpParser Var
 
-data InfixParser = Symbol | Ident | ConsOp | Custom
+data OpParser = Symbol | Ident | ConsOp | Custom
 
 name :: OpDef -> Var
 name (Infix _ n _) = n
+name (Prefix _ n) = n
+name (Postfix _ n) = n
 
 -- Aim to match Python operator precedence and associativty as defined in:
 -- https://docs.python.org/3/reference/expressions.html#operator-precedence

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -2,62 +2,83 @@ module Primitive.Parse where
 
 import Prelude
 
-import Bind (Var)
 import Data.Array (length, mapWithIndex)
 import Data.Map (Map, fromFoldable, lookup)
 import Data.Maybe (Maybe(..))
 import Parsing.Expr (Assoc(..))
 import Util ((×))
 
-data OpDef
-   = Infix OpParser Var Assoc
-   | Prefix OpParser Var
-   | Postfix OpParser Var
+data OpDef = OpDef String Op
 
-data OpParser = Symbol | Ident | ConsOp | Custom
+data Op
+   = Symbol Fixity
+   | Ident Fixity
+   | CustomOp
+   | ConsOp
+   | ProjectOp
 
-name :: OpDef -> Var
-name (Infix _ n _) = n
-name (Prefix _ n) = n
-name (Postfix _ n) = n
+data Fixity = Infix Assoc | Prefix | Postfix
+
+op :: String -> Op -> OpDef
+op = OpDef
 
 -- Aim to match Python operator precedence and associativty as defined in:
 -- https://docs.python.org/3/reference/expressions.html#operator-precedence
 opDefs :: Array (Array OpDef)
 opDefs =
-   [ [ Infix Symbol "!" AssocLeft ]
-   , [ Infix Symbol "**" AssocRight ]
-   , [ Infix Symbol "*" AssocLeft
-     , Infix Symbol "/" AssocLeft
-     , Infix Symbol "//" AssocLeft
-     , Infix Symbol "%" AssocLeft
+   -- Matrix lookup
+   [ [ op "!" symbol ]
+   -- Exponentiation
+   , [ op "**" symbolR ]
+   -- Multiplication, division, floor division, remainder
+   , [ op "*" symbol
+     , op "/" symbol
+     , op "//" symbol
+     , op "%" symbol
      ]
-   , [ Infix Symbol "+" AssocLeft
-     , Infix Symbol "-" AssocLeft
+   -- Addition and subtraction
+   , [ op "+" symbol
+     , op "-" symbol
      ]
-   , [ Infix ConsOp ":" AssocRight ]
-   , [ Infix Symbol "++" AssocRight ]
-   , [ Infix Custom "|x|" AssocLeft ]
-   , [ Infix Symbol "==" AssocNone
-     , Infix Symbol "/=" AssocNone
-     , Infix Symbol "<" AssocLeft
-     , Infix Symbol ">" AssocLeft
-     , Infix Symbol "<=" AssocLeft
-     , Infix Symbol ">=" AssocLeft
+   -- Cons
+   , [ op ":" ConsOp ]
+   -- String concat
+   , [ op "++" symbolR ]
+   -- Custom operators (as Python's bitwise OR)
+   , [ op "|x|" CustomOp ]
+   -- Comparisons, including membership tests and identity tests
+   , [ op "==" symbolN
+     , op "/=" symbolN
+     , op "<" symbol
+     , op ">" symbol
+     , op "<=" symbol
+     , op ">=" symbol
      ]
-   , [ Prefix Ident "not" ]
-   , [ Infix Ident "and" AssocLeft ]
-   , [ Infix Ident "or" AssocLeft ]
+   -- Boolean NOT
+   , [ op "not" identPrefix ]
+   -- Boolean AND
+   , [ op "and" ident ]
+   -- Boolean OR
+   , [ op "or" ident ]
    ]
+
+   where
+
+   symbol = Symbol (Infix AssocLeft)
+   symbolR = Symbol (Infix AssocRight)
+   symbolN = Symbol (Infix AssocNone)
+
+   ident = Ident (Infix AssocLeft)
+   identPrefix = Ident Prefix
 
 -- name -> prec
 opPrecs :: Map String Int
 opPrecs = fromFoldable do
    i × ops <- mapWithIndex (×) opDefs
-   op <- ops
-   pure $ name op × (length opDefs - i) -- table is high-low
+   (OpDef name _) <- ops
+   pure $ name × (length opDefs - i) -- table is high-low
 
 getPrec :: String -> Int
-getPrec op = case lookup op opPrecs of
+getPrec name = case lookup name opPrecs of
    Just p -> p
    Nothing -> -1

--- a/src/Primitive/Parse.purs
+++ b/src/Primitive/Parse.purs
@@ -3,46 +3,56 @@ module Primitive.Parse where
 import Prelude
 
 import Bind (Var)
-import Data.Map (Map, fromFoldable)
+import Data.Array (length, mapWithIndex)
+import Data.Map (Map, fromFoldable, lookup)
+import Data.Maybe (Maybe(..))
 import Parsing.Expr (Assoc(..))
 import Util ((×))
 
 data OpDef =
-   Infix InfixParser Var Assoc Int
+   Infix InfixParser Var Assoc
 
 data InfixParser = Symbol | Ident | ConsOp | Custom
 
 name :: OpDef -> Var
-name (Infix _ n _ _) = n
-
-prec :: OpDef -> Int
-prec (Infix _ _ _ p) = p
+name (Infix _ n _) = n
 
 -- Aim to match Python operator precedence and associativty as defined in:
 -- https://docs.python.org/3/reference/expressions.html#operator-precedence
-opDefs :: Array OpDef
+opDefs :: Array (Array OpDef)
 opDefs =
-   [ Infix Symbol "!" AssocLeft 9
-   , Infix Symbol "**" AssocRight 8
-   , Infix Symbol "*" AssocLeft 7
-   , Infix Symbol "/" AssocLeft 7
-   , Infix Symbol "//" AssocLeft 7
-   , Infix Symbol "%" AssocLeft 7
-   , Infix Symbol "+" AssocLeft 6
-   , Infix Symbol "-" AssocLeft 6
-   , Infix ConsOp ":" AssocRight 5
-   , Infix Symbol "++" AssocRight 4
-   , Infix Custom "|x|" AssocLeft 3
-   , Infix Symbol "==" AssocNone 2
-   , Infix Symbol "/=" AssocNone 2
-   , Infix Symbol "<" AssocLeft 2
-   , Infix Symbol ">" AssocLeft 2
-   , Infix Symbol "<=" AssocLeft 2
-   , Infix Symbol ">=" AssocLeft 2
-   , Infix Ident "and" AssocLeft 1
-   , Infix Ident "or" AssocLeft 0
+   [ [ Infix Symbol "!" AssocLeft ]
+   , [ Infix Symbol "**" AssocRight ]
+   , [ Infix Symbol "*" AssocLeft
+     , Infix Symbol "/" AssocLeft
+     , Infix Symbol "//" AssocLeft
+     , Infix Symbol "%" AssocLeft
+     ]
+   , [ Infix Symbol "+" AssocLeft
+     , Infix Symbol "-" AssocLeft
+     ]
+   , [ Infix ConsOp ":" AssocRight ]
+   , [ Infix Symbol "++" AssocRight ]
+   , [ Infix Custom "|x|" AssocLeft ]
+   , [ Infix Symbol "==" AssocNone
+     , Infix Symbol "/=" AssocNone
+     , Infix Symbol "<" AssocLeft
+     , Infix Symbol ">" AssocLeft
+     , Infix Symbol "<=" AssocLeft
+     , Infix Symbol ">=" AssocLeft
+     ]
+   , [ Infix Ident "and" AssocLeft ]
+   , [ Infix Ident "or" AssocLeft ]
    ]
 
--- for lookup by name
-opMap :: Map String OpDef
-opMap = fromFoldable $ map (\def -> name def × def) opDefs
+-- name -> prec
+opPrecs :: Map String Int
+opPrecs = fromFoldable do
+   i × ops <- mapWithIndex (×) opDefs
+   op <- ops
+   pure $ name op × (length opDefs - i) -- table is high-low
+
+getPrec :: String -> Int
+getPrec op = case lookup op opPrecs of
+   Just p -> p
+   Nothing -> -1

--- a/src/SExpr.purs
+++ b/src/SExpr.purs
@@ -51,6 +51,7 @@ data Expr a
    | DProject (Expr a) (Expr a)
    | App (Expr a) (Expr a)
    | BinaryApp (Expr a) Var (Expr a)
+   | UnaryPrefixApp Var (Expr a)
    | MatchAs (Expr a) (NonEmptyList (Pattern × Expr a))
    | IfElse (NonEmptyList (Expr a × Expr a)) (Expr a)
    | Paragraph (Paragraph a)
@@ -312,6 +313,8 @@ exprFwd (App s1 s2) =
    E.App <$> desug s1 <*> desug s2
 exprFwd (BinaryApp s1 op s2) =
    E.App <$> (E.App (E.Op op) <$> desug s1) <*> desug s2
+exprFwd (UnaryPrefixApp op s) =
+   E.App (E.Op op) <$> desug s
 exprFwd (MatchAs s μ) =
    E.App <$> (E.Lambda top <$> desug (Clauses (Clause <$> first singleton <$> μ))) <*> desug s
 exprFwd (IfElse sss s) =
@@ -361,6 +364,8 @@ exprBwd (E.App e1 e2) (App s1 s2) =
    App (desugBwd e1 s1) (desugBwd e2 s2)
 exprBwd (E.App (E.App (E.Op _) e1) e2) (BinaryApp s1 op s2) =
    BinaryApp (desugBwd e1 s1) op (desugBwd e2 s2)
+exprBwd (E.App (E.Op _) e) (UnaryPrefixApp op s) =
+   UnaryPrefixApp op (desugBwd e s)
 exprBwd (E.App (E.Lambda _ σ) e) (MatchAs s μ) =
    MatchAs (desugBwd e s)
       (first head <$> unwrap <$> unwrap (desugBwd σ (Clauses (Clause <$> first singleton <$> μ))))

--- a/test/Specs/Misc.purs
+++ b/test/Specs/Misc.purs
@@ -42,6 +42,7 @@ misc_cases =
      , fwd_expect: """Paragraph(Text("As shown in Table 3, BiLSTM gives significantly  ") :| Text("better") :| [])"""
      }
    , { file: "pattern-match.fld", fwd_expect: "4" }
+   , { file: "prefix-op.fld", fwd_expect: "True" }
    , { file: "range.fld", fwd_expect: "(0, 0) :| (0, 1) :| (1, 0) :| (1, 1) :| []" }
    , { file: "records.fld", fwd_expect: "{ a: 2, b: 6, c: 7, d: 5 :| [], e: 7 }" }
    , { file: "record-lookup.fld", fwd_expect: "True" }

--- a/test/fluid/prefix-op.fld
+++ b/test/fluid/prefix-op.fld
@@ -1,1 +1,3 @@
 not False and not (not True)
+    and
+        not False and not not True

--- a/test/fluid/prefix-op.fld
+++ b/test/fluid/prefix-op.fld
@@ -1,0 +1,1 @@
+not False and not (not True)


### PR DESCRIPTION
This PR refactors `opDefs`/`opTable` to prepare for handling prefix/postfix operators, and inclusion of application/projection in the precedence table.

Changes:

- Remove explicit precedence values in `opDefs` to make additions simpler
- Add `UnaryPrefixApp` to `SExpr`
- Add `not` as a unary prefix operator
- Update `purescript-parsing` to support chaining of prefix/postfix ops (e.g. `not not not True`)
- Move `opTable` definition inside `opTree` so that `opTree` is in scope for application/projection operators (future work)
- Other minor related refactoring