### PR TITLE
Move completed manual tasks to reports

### DIFF
--- a/.github/workflows/check-project-integrity.yml
+++ b/.github/workflows/check-project-integrity.yml
@@ -1,0 +1,17 @@
+name: check-project-integrity
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly on Monday at 08:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check project integrity
+      env:
+        GH_TOKEN: ${{ secrets.PROJECT_PAT }}
+      run: |
+        ./script/check-project-integrity.sh fluid

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,5 @@ Continual improvement of the workflow itself, including documenting the workflow
 ## Process
 
 See [docs/workflow/process.md](docs/workflow/process.md) for the development process, GitHub conventions, and tracking approach.
+
+See [docs/workflow/milestone-report.md](docs/workflow/milestone-report.md) for the milestone report format and generation process.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,4 +21,6 @@ Continual improvement of the workflow itself, including documenting the workflow
 
 See [docs/workflow/process.md](docs/workflow/process.md) for the development process, GitHub conventions, and tracking approach.
 
+See [docs/workflow/issue-lifecycle.md](docs/workflow/issue-lifecycle.md) for the issue state machine, transitions, and invariants.
+
 See [docs/workflow/milestone-report.md](docs/workflow/milestone-report.md) for the milestone report format and generation process.

--- a/docs/reports/completed-manual-tasks.md
+++ b/docs/reports/completed-manual-tasks.md
@@ -1,0 +1,8 @@
+# Completed Manual Tasks
+
+- Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
+- Add "Awaiting Decision" status option to the GitHub Project board (created via GraphQL API once token scope was granted)
+- Rename milestone "fluid-org 1.0" to "fluid 0.13"
+- Create milestone branch `fluid-0.12` from develop
+- Create milestone branch `fluid-0.13` from develop
+- Add `PROJECT_PAT` secret to the repo (a PAT with `project` scope) for the `check-project-integrity` GitHub Actions workflow

--- a/docs/reports/fluid-0.12.md
+++ b/docs/reports/fluid-0.12.md
@@ -51,10 +51,10 @@
 
 ## Metrics
 - Total commits: ~97
-- Claude-authored commits: not tracked for early issues (co-author convention adopted mid-milestone)
-- Human-authored commits: majority
-- Issues completed autonomously: 3 (#1485, #1459, #1385)
-- Issues requiring human intervention: 3 (#1489, #1491, #1434)
+- Claude-authored commits: ~0% (co-author convention adopted mid-milestone; actual Claude contribution higher but unattributed)
+- Human-authored commits: ~100% (by attribution; see notes)
+- Issues completed autonomously: 3 (50%) — #1485, #1459, #1385
+- Issues requiring human intervention: 3 (50%) — #1489, #1491, #1434
 
 ## Notes
 - The `Co-Authored-By: Claude` convention was adopted partway through this milestone. Earlier commits lack this attribution. Future milestones will have accurate tracking from the start.

--- a/docs/reports/fluid-0.12.md
+++ b/docs/reports/fluid-0.12.md
@@ -1,0 +1,61 @@
+# Milestone: fluid 0.12
+
+## Summary
+- Issues completed: 6
+- Issues remaining: TBD
+- Date range: 2026-02-04 to ongoing
+
+## Issues
+
+### #1489: Svelte components for Fluid web pages
+- **Status**: Done
+- **Commits**: 84 total, 0 attributed to Claude (predates co-author convention)
+- **Files modified**: ~837 (excluding output dirs)
+- **Decision points**: human-driven (initial Svelte migration design)
+- **Branch**: `Svelte-components` → develop (PR #1494)
+
+### #1491: Migrate `article` and `literate-execution` to SvelteKit
+- **Status**: Done
+- **Commits**: included in #1489 branch
+- **Decision points**: human intervention
+  - CSS scoping: view-styles.css initially scoped under `#fig`, broke data pane styling; reverted to global
+
+### #1485: Matrix index resolution out by 1 on mouseover
+- **Status**: Done
+- **Commits**: 2 total, 0 by Claude
+- **Files modified**: 2
+- **Decision points**: autonomous
+- **Branch**: `convolution-mouseover-bug` → develop (PR #1486)
+
+### #1459: Unary `not`
+- **Status**: Done
+- **Commits**: 9 total, 0 by Claude
+- **Files modified**: 7
+- **Decision points**: autonomous
+- **Branch**: `op-table-fixities` → develop (PR #1493)
+
+### #1434: Migrate remaining website tests to JavaScript
+- **Status**: Done
+- **Commits**: 2 on dedicated branch (bulk of work done on `Svelte-components` branch before workflow conventions adopted)
+- **Files modified**: ~20 (webtest-lib.mjs, test files, PureScript test cleanup)
+- **Decision points**: human intervention
+  - Chose plain JS over PureScript Aff-based test utilities
+  - CSS regression test approach discussed; `checkComputedStyle` added
+- **Branch**: `1434-migrate-PureScript-website-tests` → develop (PR #1495)
+
+### #1385: PureScript website tests ignored on Ubuntu
+- **Status**: Done (resolved by #1434)
+- **Commits**: 0 (no dedicated work; resolved as side effect of #1434)
+- **Files modified**: 0
+- **Decision points**: autonomous (identified as already resolved, closed with comment)
+
+## Metrics
+- Total commits: ~97
+- Claude-authored commits: not tracked for early issues (co-author convention adopted mid-milestone)
+- Human-authored commits: majority
+- Issues completed autonomously: 3 (#1485, #1459, #1385)
+- Issues requiring human intervention: 3 (#1489, #1491, #1434)
+
+## Notes
+- The `Co-Authored-By: Claude` convention was adopted partway through this milestone. Earlier commits lack this attribution. Future milestones will have accurate tracking from the start.
+- The branching workflow (issue → milestone → develop) was also adopted mid-milestone. Earlier issues went directly to develop.

--- a/docs/workflow/incidents.md
+++ b/docs/workflow/incidents.md
@@ -1,0 +1,13 @@
+# Workflow Incidents
+
+## 2026-03-22: Project board status assignments lost
+
+**What happened**: Using the `updateProjectV2Field` GraphQL mutation to add an "Awaiting Decision" status option replaced all existing status options with new IDs. This orphaned all existing status assignments across 1058 project items.
+
+**Root cause**: The GitHub Projects API requires all options to be specified when updating a single-select field — there is no "append option" operation. The mutation created new option IDs even for options with the same names, breaking all existing assignments.
+
+**Impact**: All project item statuses (In Progress, Paused, Done, etc.) were lost.
+
+**Lesson**: Destructive mutations on shared project state must be flagged for human approval, even when the token has permission. This falls under the same category as force-pushing or dropping database tables.
+
+**Action**: Added to escalation criteria in process doc.

--- a/docs/workflow/issue-lifecycle.md
+++ b/docs/workflow/issue-lifecycle.md
@@ -1,0 +1,61 @@
+# Issue Lifecycle
+
+## States
+
+### Open — passive
+Issues not currently being worked on.
+
+- **Proposed**: candidate for future work; not yet prioritised.
+- **Planned**: prioritised for inclusion in a milestone. Adding an issue to a milestone bumps it from Proposed to Planned.
+
+### Open — active
+Issues currently being worked on or blocked.
+
+- **In Progress**: actively being worked on.
+- **Paused**: was in progress but temporarily stopped (e.g. by human request).
+- **Awaiting Decision**: blocked on a decision requiring human input.
+
+### Closed
+- **Done**: completed.
+- **Rejected**: will not be done.
+
+## Transitions
+
+```
+Proposed ──→ Planned ──→ In Progress ──→ Done
+                              │
+                              ├──→ Paused ──→ In Progress
+                              │
+                              └──→ Awaiting Decision ──→ In Progress
+                                                     └──→ Paused
+
+Any open state ──→ Rejected
+```
+
+- **Proposed → Planned**: issue is prioritised, or added to a milestone.
+- **Planned → In Progress**: work begins.
+- **In Progress → Paused**: temporarily stopped (e.g. waiting on unrelated work, human request).
+- **In Progress → Awaiting Decision**: blocked on a decision; Claude adds a comment explaining the options.
+- **Awaiting Decision → In Progress**: decision made, work resumes.
+- **Awaiting Decision → Paused**: decision is to defer.
+- **In Progress → Done**: work complete, PR merged.
+
+## Invariants
+
+Enforced by `script/check-project-integrity.sh`:
+
+- Every open issue has a Status.
+- No milestoned issue is Proposed (should be Planned or higher).
+- Every active issue (In Progress, Paused, Awaiting Decision) has a milestone.
+- In a closed milestone, all issues are Done or Rejected.
+
+## Other statuses
+
+- **Meeting**: used for non-issue items on the project board. Not part of the issue lifecycle and excluded from integrity checks.
+
+## Milestone closure
+
+Before closing a milestone:
+1. All active issues (In Progress, Paused, Awaiting Decision) must be removed from the milestone.
+2. Removed issues drop back to Planned (no milestone).
+3. Only Done and Rejected issues remain in the closed milestone.

--- a/docs/workflow/milestone-report.md
+++ b/docs/workflow/milestone-report.md
@@ -1,0 +1,44 @@
+# Milestone Report Format
+
+A milestone report is generated when a milestone branch is merged to develop. It provides an audit trail and metrics for the work done.
+
+## Format
+
+```
+# Milestone: <name>
+
+## Summary
+- Issues completed: N
+- Issues remaining: N (with statuses)
+- Date range: YYYY-MM-DD to YYYY-MM-DD
+
+## Issues
+
+### #<number>: <title>
+- **Status**: Done | Awaiting Decision | Paused
+- **Commits**: N total, N by Claude, N by human
+- **Files modified**: N
+- **Decision points**: autonomous | human intervention required
+  - <brief description of any decisions escalated or made>
+
+(repeated for each issue)
+
+## Metrics
+- Total commits: N
+- Claude-authored commits: N (N%)
+- Human-authored commits: N (N%)
+- Total files modified: N
+- Issues completed autonomously: N
+- Issues requiring human intervention: N
+```
+
+## Generation
+
+The report is generated from git history and GitHub issue data:
+- Commits attributed to Claude are identified by the `Co-Authored-By: Claude` trailer.
+- Decision points are identified from GitHub issue comments and "Awaiting Decision" status transitions.
+- File counts come from `git diff --stat` between the milestone branch base and head.
+
+## Storage
+
+Reports are committed to `docs/reports/<milestone-name>.md` (e.g. `docs/reports/fluid-0.12.md`).

--- a/docs/workflow/milestone-report.md
+++ b/docs/workflow/milestone-report.md
@@ -60,9 +60,11 @@ Stored at `docs/reports/<milestone-name>.md`.
 
 ## Generation
 
-Both documents are generated from:
+**Milestone reports** are built incrementally: each issue's entry is added when the issue is closed. The summary and metrics sections are updated at the same time. This keeps the report current throughout the milestone.
+
+**Release notes** are generated when the milestone branch is merged to develop, categorised by issue labels (`implementation` → Features, `testing`/`setup` → Other, etc.) and can be edited before publishing.
+
+Both draw from:
 - **Git history**: commits on the milestone branch since it diverged from develop. Claude-authored commits identified by `Co-Authored-By: Claude` trailer.
 - **GitHub issues**: status, labels, and comments. Decision points identified from "Awaiting Decision" status transitions and escalation comments.
 - **File counts**: `git diff --stat` between the milestone branch base and head.
-
-Release notes are categorised by issue labels (`implementation` → Features, `testing`/`setup` → Other, etc.) and can be edited before publishing.

--- a/docs/workflow/milestone-report.md
+++ b/docs/workflow/milestone-report.md
@@ -1,8 +1,34 @@
-# Milestone Report Format
+# Milestone Reports and Release Notes
 
-A milestone report is generated when a milestone branch is merged to develop. It provides an audit trail and metrics for the work done.
+When a milestone branch is merged to develop, two documents are generated from the same git history and GitHub issue data.
 
-## Format
+## Release notes
+
+Outward-facing summary of what changed. Audience: users and contributors.
+
+Stored at `docs/releases/<milestone-name>.md`.
+
+```
+# <milestone-name>
+
+## Features
+- <one-line description> (#<issue>)
+
+## Bug fixes
+- <one-line description> (#<issue>)
+
+## Breaking changes
+- <one-line description> (#<issue>)
+
+## Other
+- <one-line description> (#<issue>)
+```
+
+## Milestone report
+
+Inward-facing audit trail and metrics. Audience: development team.
+
+Stored at `docs/reports/<milestone-name>.md`.
 
 ```
 # Milestone: <name>
@@ -34,11 +60,9 @@ A milestone report is generated when a milestone branch is merged to develop. It
 
 ## Generation
 
-The report is generated from git history and GitHub issue data:
-- Commits attributed to Claude are identified by the `Co-Authored-By: Claude` trailer.
-- Decision points are identified from GitHub issue comments and "Awaiting Decision" status transitions.
-- File counts come from `git diff --stat` between the milestone branch base and head.
+Both documents are generated from:
+- **Git history**: commits on the milestone branch since it diverged from develop. Claude-authored commits identified by `Co-Authored-By: Claude` trailer.
+- **GitHub issues**: status, labels, and comments. Decision points identified from "Awaiting Decision" status transitions and escalation comments.
+- **File counts**: `git diff --stat` between the milestone branch base and head.
 
-## Storage
-
-Reports are committed to `docs/reports/<milestone-name>.md` (e.g. `docs/reports/fluid-0.12.md`).
+Release notes are categorised by issue labels (`implementation` → Features, `testing`/`setup` → Other, etc.) and can be edited before publishing.

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -22,9 +22,17 @@ issue branch → milestone branch → develop
 - **PRs from issue branches to milestone branches**: Claude can merge directly once CI passes (no human approval required).
 - **PRs from milestone branches to develop**: human decides when to merge.
 
+## Milestone population
+
+When all issues in a milestone are either done, paused, or awaiting decision, Claude should populate it with 3-8 new issues (depending on anticipated difficulty). Candidates are chosen by:
+
+1. **Planned issues first**: issues with status "Planned" but not yet assigned to a milestone have already been prioritised by the human and are strong candidates.
+2. **Proposed issues**: for remaining slots, select from "Proposed" issues, preferring low-hanging fruit — low risk, thematic fit with the milestone, alignment with apparent priorities, and availability of test coverage.
+3. Claude should present the proposed selection for human approval before assigning issues to the milestone.
+
 ## Issue lifecycle
 
-1. **Selection**: Pick an issue based on risk/reward. Prefer issues with existing test coverage or where tests can be added.
+1. **Selection**: Pick an issue from the current milestone. Prefer issues with existing test coverage or where tests can be added.
 2. **Branch**: Create an issue branch from the relevant milestone branch.
 3. **Implementation**: Work incrementally, committing after each non-trivial step.
 4. **Testing**: Run `./script/test-website-all.sh` and any other relevant tests before declaring done.

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -7,22 +7,29 @@ After every non-trivial step, Claude must pause, briefly review what was done, a
 - The human can intervene or redirect at any point
 - Progress is never lost to a context window limit or interrupted session
 
+## Branching
+
+All issues belong to a milestone. Milestones are named `<repo> <major>.<minor>` (e.g. `fluid 0.12`).
+
+**Branch structure:**
+
+```
+issue branch → milestone branch → develop
+```
+
+- **Milestone branches** are named to match the milestone (e.g. `fluid-0.12`). They serve as integration branches for related work.
+- **Issue branches** are named `<issue-number>-<short-description>` and branch from the relevant milestone branch.
+- **PRs from issue branches to milestone branches**: Claude can merge directly once CI passes (no human approval required).
+- **PRs from milestone branches to develop**: human decides when to merge.
+
 ## Issue lifecycle
 
 1. **Selection**: Pick an issue based on risk/reward. Prefer issues with existing test coverage or where tests can be added.
-2. **Branch**: Create a branch named `<issue-number>-<short-description>`.
+2. **Branch**: Create an issue branch from the relevant milestone branch.
 3. **Implementation**: Work incrementally, committing after each non-trivial step.
 4. **Testing**: Run `./script/test-website-all.sh` and any other relevant tests before declaring done.
-5. **PR**: Push branch and create PR linking the issue.
-6. **Review and merge**: See below.
-
-## PR flow
-
-All changes go through PRs, even when the committer has bypass permissions. This maintains the audit trail.
-
-**Current state**: Claude creates PRs; human reviews, approves, and merges.
-
-**Goal**: Evolve towards Claude-based PR approval, with human intervention only when necessary (e.g. architectural decisions, risky changes, external-facing changes). This requires either a dedicated bot account or organisation-level policy changes.
+5. **PR**: Push branch and create PR targeting the milestone branch.
+6. **Merge**: Claude merges to milestone branch once CI passes. Human merges milestone branch to develop.
 
 ## Escalation
 
@@ -56,7 +63,7 @@ Claude must describe the intended change and its blast radius, and wait for appr
 ## GitHub conventions
 
 - **Labels**: Use existing labels (`implementation`, `testing`, `setup`, `documentation`). Add `claude-automated` for issues where Claude drove the implementation.
-- **Milestones**: Respect existing milestone assignments; don't reassign without human approval.
+- **Milestones**: All issues must belong to a milestone. Don't reassign without human approval.
 - **Issue bodies**: Keep checklist items updated as work progresses.
 
 ## Manual setup requirements
@@ -77,3 +84,6 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 
 - [x] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
 - [x] Add "Awaiting Decision" status option to the GitHub Project board (created via GraphQL API once token scope was granted)
+- [ ] Rename milestone "fluid-org 1.0" to "fluid 0.13"
+- [ ] Create milestone branch `fluid-0.12` from develop
+- [ ] Create milestone branch `fluid-0.13` from develop

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -100,3 +100,4 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 - [x] Rename milestone "fluid-org 1.0" to "fluid 0.13"
 - [x] Create milestone branch `fluid-0.12` from develop
 - [x] Create milestone branch `fluid-0.13` from develop
+- [ ] Add `PROJECT_PAT` secret to the repo (a PAT with `project` scope) for the `check-project-integrity` GitHub Actions workflow

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -20,7 +20,7 @@ issue branch → milestone branch → develop
 - **Milestone branches** are named to match the milestone (e.g. `fluid-0.12`). They serve as integration branches for related work.
 - **Issue branches** are named `<issue-number>-<short-description>` and branch from the relevant milestone branch.
 - **PRs from issue branches to milestone branches**: Claude can merge directly once CI passes (no human approval required).
-- **PRs from milestone branches to develop**: human decides when to merge.
+- **PRs from milestone branches to develop**: human decides when to merge. A [milestone report](milestone-report.md) is generated at this point.
 
 ## Milestone population
 

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -42,6 +42,10 @@ The comment should be self-contained so the human can make the decision asynchro
 
 Claude must describe the intended change and its blast radius, and wait for approval. Having token permission is not sufficient justification to proceed. See [incidents.md](incidents.md) for examples of what can go wrong.
 
+**There is no undo facility for GitHub Projects v2 field mutations.** Changes to field definitions (options, names, types) are irreversible via the API.
+
+**After any change to project board state** (item statuses, field values, milestones), Claude must verify the project view at https://github.com/orgs/explorable-viz/projects/1 to confirm it hasn't been broken. Project views cannot be created or edited via the API — only read — so damage to views requires manual repair.
+
 ## Tracking Claude contributions
 
 - Commits by Claude include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -100,4 +100,4 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 - [x] Rename milestone "fluid-org 1.0" to "fluid 0.13"
 - [x] Create milestone branch `fluid-0.12` from develop
 - [x] Create milestone branch `fluid-0.13` from develop
-- [ ] Add `PROJECT_PAT` secret to the repo (a PAT with `project` scope) for the `check-project-integrity` GitHub Actions workflow
+- [x] Add `PROJECT_PAT` secret to the repo (a PAT with `project` scope) for the `check-project-integrity` GitHub Actions workflow

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -63,5 +63,5 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 
 ## Pending manual tasks
 
-- [ ] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
-- [ ] Add "Awaiting Decision" status option to the GitHub Project board (project settings → Status field → add option)
+- [x] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
+- [x] Add "Awaiting Decision" status option to the GitHub Project board (created via GraphQL API once token scope was granted)

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -84,6 +84,6 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 
 - [x] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
 - [x] Add "Awaiting Decision" status option to the GitHub Project board (created via GraphQL API once token scope was granted)
-- [ ] Rename milestone "fluid-org 1.0" to "fluid 0.13"
-- [ ] Create milestone branch `fluid-0.12` from develop
-- [ ] Create milestone branch `fluid-0.13` from develop
+- [x] Rename milestone "fluid-org 1.0" to "fluid 0.13"
+- [x] Create milestone branch `fluid-0.12` from develop
+- [x] Create milestone branch `fluid-0.13` from develop

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -47,8 +47,21 @@ The comment should be self-contained so the human can make the decision asynchro
 - **Milestones**: Respect existing milestone assignments; don't reassign without human approval.
 - **Issue bodies**: Keep checklist items updated as work progresses.
 
+## Manual setup requirements
+
+Some workflow capabilities depend on GitHub settings (token scopes, project board configuration, branch protection rules) that cannot be changed by Claude. When Claude encounters a missing permission or setting, it should:
+
+1. Document the requirement in the pending tasks section below.
+2. Note the specific setting change needed and why.
+3. Continue with available work.
+
 ## Token permissions
 
 The `gh` CLI token needs the following scopes for full workflow automation:
 - `repo` scope (includes issues, PRs, comments), or for fine-grained tokens: **Issues: Read and write**
 - `project` scope — needed to update project board statuses (e.g. moving issues to "Awaiting Decision")
+
+## Pending manual tasks
+
+- [ ] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
+- [ ] Add "Awaiting Decision" status option to the GitHub Project board (project settings → Status field → add option)

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -28,7 +28,8 @@ When all issues in a milestone are either done, paused, or awaiting decision, Cl
 
 1. **Planned issues first**: issues with status "Planned" but not yet assigned to a milestone have already been prioritised by the human and are strong candidates.
 2. **Proposed issues**: for remaining slots, select from "Proposed" issues, preferring low-hanging fruit — low risk, thematic fit with the milestone, alignment with apparent priorities, and availability of test coverage.
-3. Claude should present the proposed selection for human approval before assigning issues to the milestone.
+
+This can be done autonomously — no human approval needed.
 
 ## Issue lifecycle
 

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -24,6 +24,16 @@ All changes go through PRs, even when the committer has bypass permissions. This
 
 **Goal**: Evolve towards Claude-based PR approval, with human intervention only when necessary (e.g. architectural decisions, risky changes, external-facing changes). This requires either a dedicated bot account or organisation-level policy changes.
 
+## Escalation
+
+When the best way to proceed isn't obvious, Claude should not guess — instead:
+
+1. Add a comment to the GitHub issue explaining the decision required, the options considered, and a recommendation if possible.
+2. Move the issue to "Awaiting Decision" status in the GitHub Project board.
+3. Stop work on that issue and move to other work if available.
+
+The comment should be self-contained so the human can make the decision asynchronously.
+
 ## Tracking Claude contributions
 
 - Commits by Claude include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.
@@ -41,3 +51,4 @@ All changes go through PRs, even when the committer has bypass permissions. This
 
 The `gh` CLI token needs the following scopes for full workflow automation:
 - `repo` scope (includes issues, PRs, comments), or for fine-grained tokens: **Issues: Read and write**
+- `project` scope — needed to update project board statuses (e.g. moving issues to "Awaiting Decision")

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -13,8 +13,16 @@ After every non-trivial step, Claude must pause, briefly review what was done, a
 2. **Branch**: Create a branch named `<issue-number>-<short-description>`.
 3. **Implementation**: Work incrementally, committing after each non-trivial step.
 4. **Testing**: Run `./script/test-website-all.sh` and any other relevant tests before declaring done.
-5. **PR**: Push branch, create PR linking the issue.
-6. **Review**: Human reviews, approves, merges.
+5. **PR**: Push branch and create PR linking the issue.
+6. **Review and merge**: See below.
+
+## PR flow
+
+All changes go through PRs, even when the committer has bypass permissions. This maintains the audit trail.
+
+**Current state**: Claude creates PRs; human reviews, approves, and merges.
+
+**Goal**: Evolve towards Claude-based PR approval, with human intervention only when necessary (e.g. architectural decisions, risky changes, external-facing changes). This requires either a dedicated bot account or organisation-level policy changes.
 
 ## Tracking Claude contributions
 

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -34,6 +34,8 @@ When the best way to proceed isn't obvious, Claude should not guess — instead:
 
 The comment should be self-contained so the human can make the decision asynchronously.
 
+Escalation also applies to **mutations on shared state** (project board fields, branch protection rules, organisation settings). These should always be flagged for human approval, even when the token has permission. See [incidents.md](incidents.md) for examples.
+
 ## Tracking Claude contributions
 
 - Commits by Claude include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -34,7 +34,13 @@ When the best way to proceed isn't obvious, Claude should not guess — instead:
 
 The comment should be self-contained so the human can make the decision asynchronously.
 
-Escalation also applies to **mutations on shared state** (project board fields, branch protection rules, organisation settings). These should always be flagged for human approval, even when the token has permission. See [incidents.md](incidents.md) for examples.
+**Destructive or organisation-wide changes require explicit human approval before execution.** This includes:
+- Modifying project board field definitions (adding/removing/renaming status options)
+- Changing branch protection rules
+- Modifying organisation or repository settings
+- Any GraphQL mutation that replaces rather than appends data
+
+Claude must describe the intended change and its blast radius, and wait for approval. Having token permission is not sufficient justification to proceed. See [incidents.md](incidents.md) for examples of what can go wrong.
 
 ## Tracking Claude contributions
 

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -29,7 +29,11 @@ When all issues in a milestone are either done, paused, or awaiting decision, Cl
 1. **Planned issues first**: issues with status "Planned" but not yet assigned to a milestone have already been prioritised by the human and are strong candidates.
 2. **Proposed issues**: for remaining slots, select from "Proposed" issues, preferring low-hanging fruit — low risk, thematic fit with the milestone, alignment with apparent priorities, and availability of test coverage.
 
+Adding an issue to a milestone bumps it from Proposed to Planned.
+
 This can be done autonomously — no human approval needed.
+
+After populating, run `./script/check-project-integrity.sh` to verify invariants.
 
 ## Issue lifecycle
 

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -95,9 +95,6 @@ The `gh` CLI token needs the following scopes for full workflow automation:
 
 ## Pending manual tasks
 
-- [x] Add `project` scope to the GitHub PAT so Claude can update project board statuses (needed for the escalation workflow: moving issues to "Awaiting Decision")
-- [x] Add "Awaiting Decision" status option to the GitHub Project board (created via GraphQL API once token scope was granted)
-- [x] Rename milestone "fluid-org 1.0" to "fluid 0.13"
-- [x] Create milestone branch `fluid-0.12` from develop
-- [x] Create milestone branch `fluid-0.13` from develop
-- [x] Add `PROJECT_PAT` secret to the repo (a PAT with `project` scope) for the `check-project-integrity` GitHub Actions workflow
+None.
+
+Completed tasks are recorded in [docs/reports/completed-manual-tasks.md](../reports/completed-manual-tasks.md).

--- a/script/check-project-integrity.sh
+++ b/script/check-project-integrity.sh
@@ -1,45 +1,13 @@
 #!/usr/bin/env bash
-# Validates project board integrity rules.
-# Run periodically or as part of milestone population.
 set -e
 
+REPO="${1:-fluid}"
+ORG="explorable-viz"
 ERRORS=0
 
-echo "Checking project integrity..."
+echo "Checking project integrity for $ORG/$REPO..."
 
-# Rule 1: Every open issue should have a Status
-echo ""
-echo "=== Rule: every open issue has a Status ==="
-while IFS=$'\t' read -r number title; do
-  echo "  FAIL: #$number ($title) has no Status"
-  ERRORS=$((ERRORS + 1))
-done < <(gh api graphql --paginate -f query='
-  query($endCursor: String) {
-    organization(login: "explorable-viz") {
-      projectV2(number: 1) {
-        items(first: 100, after: $endCursor) {
-          pageInfo { hasNextPage endCursor }
-          nodes {
-            fieldValueByName(name: "Status") {
-              ... on ProjectV2ItemFieldSingleSelectValue { name }
-            }
-            content {
-              ... on Issue { number title state }
-            }
-          }
-        }
-      }
-    }
-  }
-' --jq '.data.organization.projectV2.items.nodes[] | select(.content != null and .content.state == "OPEN" and .fieldValueByName == null) | [(.content.number | tostring), .content.title] | @tsv')
-
-# Rule 2: No issue assigned to a milestone should be Proposed
-echo ""
-echo "=== Rule: milestoned issues are not Proposed ==="
-while IFS=$'\t' read -r number title milestone; do
-  echo "  FAIL: #$number ($title) is Proposed but in milestone '$milestone'"
-  ERRORS=$((ERRORS + 1))
-done < <(gh api graphql --paginate -f query='
+ALL_ITEMS=$(gh api graphql --paginate -f query='
   query($endCursor: String) {
     organization(login: "explorable-viz") {
       projectV2(number: 1) {
@@ -55,6 +23,7 @@ done < <(gh api graphql --paginate -f query='
                 title
                 state
                 milestone { title }
+                repository { name }
               }
             }
           }
@@ -62,7 +31,33 @@ done < <(gh api graphql --paginate -f query='
       }
     }
   }
-' --jq '.data.organization.projectV2.items.nodes[] | select(.content != null and .content.state == "OPEN" and .content.milestone != null and .fieldValueByName.name == "Proposed") | [(.content.number | tostring), .content.title, .content.milestone.title] | @tsv')
+' --jq '[.data.organization.projectV2.items.nodes[] | select(.content != null and .content.repository.name == "'"$REPO"'")]')
+
+check() {
+  local rule="$1"
+  local filter="$2"
+  local fmt="$3"
+
+  echo ""
+  echo "=== $rule ==="
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "  FAIL: $line"
+    ERRORS=$((ERRORS + 1))
+  done < <(echo "$ALL_ITEMS" | jq -r ".[] | $filter | $fmt")
+}
+
+check "Every open issue has a Status" \
+  'select(.content.state == "OPEN" and .fieldValueByName == null)' \
+  '"#\(.content.number) (\(.content.title)): no Status"'
+
+check "Milestoned issues are not Proposed" \
+  'select(.content.state == "OPEN" and .content.milestone != null and .fieldValueByName.name == "Proposed")' \
+  '"#\(.content.number) (\(.content.title)): Proposed but in milestone \(.content.milestone.title)"'
+
+check "Active issues have a milestone" \
+  'select(.content.state == "OPEN" and .content.milestone == null and (.fieldValueByName.name == "In Progress" or .fieldValueByName.name == "Paused"))' \
+  '"#\(.content.number) (\(.content.title)): \(.fieldValueByName.name) but no milestone"'
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then

--- a/script/check-project-integrity.sh
+++ b/script/check-project-integrity.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Validates project board integrity rules.
+# Run periodically or as part of milestone population.
+set -e
+
+ERRORS=0
+
+echo "Checking project integrity..."
+
+# Rule 1: Every open issue should have a Status
+echo ""
+echo "=== Rule: every open issue has a Status ==="
+while IFS=$'\t' read -r number title; do
+  echo "  FAIL: #$number ($title) has no Status"
+  ERRORS=$((ERRORS + 1))
+done < <(gh api graphql --paginate -f query='
+  query($endCursor: String) {
+    organization(login: "explorable-viz") {
+      projectV2(number: 1) {
+        items(first: 100, after: $endCursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+            content {
+              ... on Issue { number title state }
+            }
+          }
+        }
+      }
+    }
+  }
+' --jq '.data.organization.projectV2.items.nodes[] | select(.content != null and .content.state == "OPEN" and .fieldValueByName == null) | [(.content.number | tostring), .content.title] | @tsv')
+
+# Rule 2: No issue assigned to a milestone should be Proposed
+echo ""
+echo "=== Rule: milestoned issues are not Proposed ==="
+while IFS=$'\t' read -r number title milestone; do
+  echo "  FAIL: #$number ($title) is Proposed but in milestone '$milestone'"
+  ERRORS=$((ERRORS + 1))
+done < <(gh api graphql --paginate -f query='
+  query($endCursor: String) {
+    organization(login: "explorable-viz") {
+      projectV2(number: 1) {
+        items(first: 100, after: $endCursor) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            fieldValueByName(name: "Status") {
+              ... on ProjectV2ItemFieldSingleSelectValue { name }
+            }
+            content {
+              ... on Issue {
+                number
+                title
+                state
+                milestone { title }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+' --jq '.data.organization.projectV2.items.nodes[] | select(.content != null and .content.state == "OPEN" and .content.milestone != null and .fieldValueByName.name == "Proposed") | [(.content.number | tostring), .content.title, .content.milestone.title] | @tsv')
+
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  echo "All checks passed."
+else
+  echo "$ERRORS issue(s) found."
+  exit 1
+fi

--- a/script/check-project-integrity.sh
+++ b/script/check-project-integrity.sh
@@ -33,6 +33,8 @@ ALL_ITEMS=$(gh api graphql --paginate -f query='
   }
 ' --jq '[.data.organization.projectV2.items.nodes[] | select(.content != null and .content.repository.name == "'"$REPO"'")]')
 
+CLOSED_MILESTONES=$(gh api "repos/$ORG/$REPO/milestones?state=closed" --jq '[.[].title]')
+
 check() {
   local rule="$1"
   local filter="$2"
@@ -56,8 +58,21 @@ check "Milestoned issues are not Proposed" \
   '"#\(.content.number) (\(.content.title)): Proposed but in milestone \(.content.milestone.title)"'
 
 check "Active issues have a milestone" \
-  'select(.content.state == "OPEN" and .content.milestone == null and (.fieldValueByName.name == "In Progress" or .fieldValueByName.name == "Paused"))' \
+  'select(.content.state == "OPEN" and .content.milestone == null and (.fieldValueByName.name == "In Progress" or .fieldValueByName.name == "Paused" or .fieldValueByName.name == "Awaiting Decision"))' \
   '"#\(.content.number) (\(.content.title)): \(.fieldValueByName.name) but no milestone"'
+
+echo ""
+echo "=== Closed milestones contain only Done or Rejected issues ==="
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  echo "  FAIL: $line"
+  ERRORS=$((ERRORS + 1))
+done < <(echo "$ALL_ITEMS" | jq -r --argjson closed "$CLOSED_MILESTONES" '
+  .[] | select(
+    .content.milestone != null and
+    (.content.milestone.title as $m | $closed | index($m)) and
+    (.fieldValueByName.name != "Done" and .fieldValueByName.name != "Rejected")
+  ) | "#\(.content.number) (\(.content.title)): \(.fieldValueByName.name // "no Status") in closed milestone \(.content.milestone.title)"')
 
 echo ""
 if [ "$ERRORS" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Move checked-off manual tasks from process.md to docs/reports/completed-manual-tasks.md
- Keep the process description clean; completed tasks are still recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)