### PR TITLE
Fix deploy workflow for SvelteKit fluid-org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,10 +21,14 @@ jobs:
     if: github.ref == 'refs/heads/release'
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
     - name: build
       run: |
         yarn install
         yarn workspace @explorable-viz/fluid build
+        yarn workspace fluid-org build
     - name: gh-pages
       uses: peaceiris/actions-gh-pages@v3
       with:


### PR DESCRIPTION
## Summary
- Add `setup-node` step (was missing)
- Add `yarn workspace fluid-org build` to build the SvelteKit site before publishing to gh-pages
- The old workflow only ran the PureScript build, so `website/fluid-org/build` was never populated

Partial fix for #1490.

## Test plan
- [ ] Merge to `release` branch and verify f.luid.org is updated
- Can't test the deploy step directly from this branch since it only triggers from `release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)