### PR TITLE
Deploy from staging branch with rollback support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
   deploy-fluid-org:
     runs-on: ubuntu-22.04
     needs: build
-    if: github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/staging'
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/docs/workflow/process.md
+++ b/docs/workflow/process.md
@@ -14,13 +14,26 @@ All issues belong to a milestone. Milestones are named `<repo> <major>.<minor>` 
 **Branch structure:**
 
 ```
-issue branch → milestone branch → develop
+issue branch → milestone branch → develop → staging → release
 ```
 
 - **Milestone branches** are named to match the milestone (e.g. `fluid-0.12`). They serve as integration branches for related work.
 - **Issue branches** are named `<issue-number>-<short-description>` and branch from the relevant milestone branch.
 - **PRs from issue branches to milestone branches**: Claude can merge directly once CI passes (no human approval required).
 - **PRs from milestone branches to develop**: human decides when to merge. A [milestone report](milestone-report.md) is generated at this point.
+
+## Deployment
+
+```
+develop → staging → release
+```
+
+Deployments are managed manually by the human.
+
+1. **Merge `develop` to `staging`**: triggers the deploy workflow, which builds and publishes the `fluid-org` SvelteKit site to GitHub Pages (f.luid.org).
+2. **Test the live site.**
+3. **If good**: merge `staging` to `release`. `release` always reflects the last-known-good deployment.
+4. **If broken**: reset `staging` to `release` to roll back.
 
 ## Milestone population
 


### PR DESCRIPTION
## Summary
- Change deploy trigger from `release` to `staging` branch
- Create `staging` branch from `release`
- Document deployment flow: develop → staging → test → release
- Rollback by resetting `staging` to `release`

Partial fix for #1490.

## Test plan
- [ ] Merge develop → staging and verify f.luid.org is updated
- [ ] Verify rollback by resetting staging to release

🤖 Generated with [Claude Code](https://claude.com/claude-code)