### PR TITLE
Rewrite README for end-users; move dev setup to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to Fluid
+
+## Development setup
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 22
+- Enable Yarn via [Corepack](https://nodejs.org/api/corepack.html): `corepack enable`
+- git
+- (Windows only) [Ubuntu WSL](https://ubuntu.com/desktop/wsl)
+
+### Initial configuration
+
+```bash
+git clone git@github.com:explorable-viz/fluid.git
+cd fluid
+./script/setup/dev-setup.sh
+yarn install
+```
+
+## Building
+
+```bash
+yarn workspace @explorable-viz/fluid build
+```
+
+This compiles PureScript, bundles the Fluid runtime, and produces `output-es/` (ES module output).
+
+## Running websites locally
+
+The websites are SvelteKit apps under `website/`. To run one in dev mode:
+
+```bash
+cd website/article
+yarn dev
+```
+
+For a production-like preview:
+
+```bash
+yarn build && yarn preview
+```
+
+## Testing
+
+### PureScript unit tests
+
+```bash
+yarn workspace @explorable-viz/fluid test
+```
+
+### Website tests (Puppeteer)
+
+Tests all SvelteKit websites with Puppeteer (Chrome and Firefox):
+
+```bash
+./script/test-website-all.sh
+```
+
+Or test a single website:
+
+```bash
+cd website/article
+yarn test
+```
+
+### Browser tests
+
+```bash
+yarn workspace @explorable-viz/fluid test-browser
+```
+
+Opens a browser window; check the JavaScript console for test results.
+
+## VS Code
+
+- Install the [PureScript IDE](https://marketplace.visualstudio.com/items?itemName=nwolverson.ide-purescript) extension
+- In extension settings, select `Add Npm Path`
+- Avoid having PureScript installed globally
+
+Windows users:
+- Launch VS Code from the Ubuntu (WSL) terminal
+- Install the WSL extension
+
+## Workflow
+
+See [CLAUDE.md](CLAUDE.md) for the development workflow, including branching strategy, issue lifecycle, and milestone management.

--- a/README.md
+++ b/README.md
@@ -1,95 +1,46 @@
 ## Fluid: Language-integrated data provenance
 
-Fluid is a pure functional programming language, with a provenance-tracking runtime and Pythonic syntax. Fluid is implemented in PureScript and runs in the browser.
+Fluid is a pure functional programming language with a provenance-tracking runtime and [Pythonic syntax](https://github.com/pure-py/pure-py-spec). Fluid is implemented in PureScript and runs in the browser.
 
-[![develop](https://github.com/explorable-viz/fluid/actions/workflows/develop.yml/badge.svg)](https://github.com/explorable-viz/fluid/actions/workflows/develop.yml)
-[![GitHub pages](https://github.com/explorable-viz/fluid/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/explorable-viz/fluid/actions/workflows/pages/pages-build-deployment)
+[![build](https://github.com/explorable-viz/fluid/actions/workflows/deploy.yml/badge.svg)](https://github.com/explorable-viz/fluid/actions/workflows/deploy.yml)
 
-## End-user setup
+Website: [f.luid.org](https://f.luid.org)
 
-### Software required
-- Node.js >=18.0.0
-- yarn >= 1.22
+## Getting started
 
-### Initial configuration
+### Prerequisites
 
-Building a Fluid website usually involves building a Node application:
+- [Node.js](https://nodejs.org/) >= 22
+- Enable Yarn via [Corepack](https://nodejs.org/api/corepack.html): `corepack enable`
 
-- `yarn add @explorable-viz/fluid`
-- `yarn install` to install Node dependencies
-- `yarn install-website article` to copy example article website from `@exploreable-viz/fluid`
-- Add `dist/` and `website/` folders to `.gitignore` 
+### Creating a Fluid project
 
-### Bundling and serving website
-- `yarn bundle-website $WEBSITE_NAME` to bundle website to `dist/$WEBSITE_NAME`
-- `npx http-serve dist/$WEBSITE_NAME -c-1` to serve website at localhost
+```bash
+mkdir my-project && cd my-project
+yarn init -y
+yarn add @explorable-viz/fluid
+```
 
-## Development setup
-
-### Additional software required
-- git
-- (Windows only) [Ubuntu WSL](https://ubuntu.com/desktop/wsl)
-
-### Initial configuration
-
-- Clone repository (for Windows users, under Ubuntu WSL)
-- Run `./script/setup/dev-setup.sh` from the top-level directory
-- `yarn install` to install Node dependencies
-
-## Use
-
-- `yarn build` to build interpreter
+For an example of a Fluid website built with SvelteKit, see the [`article`](website/article) directory in this repo, or the [fluid-article](https://github.com/explorable-viz/fluid-article) template repository.
 
 ### Running programs from the command line
 
-Fluid examples in the `dist/fluid/fluid` can be evaluated from the command line as follows
-(from the top-level directory):
+Fluid programs (`.fld` files) can be evaluated from the command line:
 
 ```
 npx fluid evaluate -f <path>
 ```
-Note that the path is relative and should not include the `.fld` extension, e.g. for the `range.fld` example:
+
+The path is relative and should not include the `.fld` extension:
+
 ```
-% npx fluid evaluate -f example/range
-((0, 0) : ((0, 1) : ((1, 0) : ((1, 1) : []))))
-Success
+npx fluid evaluate -f example/range
 ```
 
-### Running websites locally (as part of Fluid development)
-As an example, to build and run the website `literate-execution`:
-- `yarn build` to ensure Fluid source code has been compiled (can be skipped on subsequent runs)
-- `yarn bundle-website literate-execution` (can be skipped if the website being run is `fluid-org`)
-- `yarn serve literate-execution` (you may be prompted to proceed; press `y`)
-- Open a browser to the served URL (defaults to `127.0.0.1:8080`)
+### VS Code setup
 
-Note: `yarn bundle-serve` is a convenient shorthand for `yarn bundle-website` followed by `yarn serve`
+Install the [MagicPython](https://marketplace.visualstudio.com/items?itemName=MagicStack.MagicPython) extension for Python syntax highlighting of `.fld` files.
 
-## Testing
+## Contributing
 
-### Running the tests from the command line
-
-After building, tests can be run from the command line via `yarn test-all`
-
-### Running tests in browser
-- As per command-line tests above, but run `yarn test-browser`, which opens
-a browser window.
-- To observe the status of tests, click `Debug` in the browser window, and then open the JavaScript Console for your browser (e.g., via the Developer Tools).
-
-### Run Puppeteer tests for website X
-
-- `yarn bundle-website X`
-- `yarn test-website X`
-
-Rebuild with `puppeteerTests.headless` set to `false` to run in browser.
-
-## Development via VS Code
-
-The following are some notes on developing Fluid using VS Code.
-
-- Avoid having PureScript installed globally
-- Install the PureScript IDE extension
-- In the PureScript IDE extension settings, select `Add Npm Path`
-
-- For Windows users:
-	- Launch VSCode through Ubuntu (WSL) terminal
-	- Install WSL extension in VSCode
+See [CONTRIBUTING.md](CONTRIBUTING.md) for developer setup, building, testing, and the development workflow.


### PR DESCRIPTION
## Summary
- README now focused on end-users: prerequisites, getting started, CLI usage, VS Code setup
- Developer instructions moved to CONTRIBUTING.md with updated commands for current setup
- Removed references to deleted scripts (bundle-website, install-website, test-website X)
- Links to PurePy spec, f.luid.org, and fluid-article template

Closes #1484.

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)