### PR TITLE
Test deployed website after gh-pages publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,3 +35,20 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: website/fluid-org/build
         keep_files: false
+    - name: wait for GitHub Pages
+      run: |
+        echo "Waiting for GitHub Pages to rebuild..."
+        sleep 30
+        for i in $(seq 1 30); do
+          if curl -sf https://f.luid.org/ > /dev/null 2>&1; then
+            echo "Site is live."
+            break
+          fi
+          echo "Attempt $i: not ready yet..."
+          sleep 10
+        done
+    - name: test deployed website
+      run: |
+        yarn puppeteer browsers install chrome
+        yarn puppeteer browsers install firefox
+        BASE_URL="https://f.luid.org" node -e "import('./website/fluid-org/test.mjs').then(({ main }) => main()).then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); })"

--- a/script/test-deployed-website.sh
+++ b/script/test-deployed-website.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Test the deployed website at a given base URL.
+# Usage: test-deployed-website.sh <base-url> <website-dir>
+set -e
+
+BASE_URL="$1"
+WEBSITE_DIR="$2"
+
+if [ -z "$BASE_URL" ] || [ -z "$WEBSITE_DIR" ]; then
+   echo "Usage: $0 <base-url> <website-dir>" >&2
+   exit 1
+fi
+
+if [ ! -f "$WEBSITE_DIR/test.mjs" ]; then
+   echo "No test.mjs found in $WEBSITE_DIR" >&2
+   exit 1
+fi
+
+echo "Testing deployed website at $BASE_URL..."
+
+# Install Puppeteer browsers
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT/fluid"
+yarn puppeteer browsers install chrome
+yarn puppeteer browsers install firefox
+
+cd "$REPO_ROOT/$WEBSITE_DIR"
+
+echo "Running tests against $BASE_URL..."
+BASE_URL="$BASE_URL" node -e "import('./test.mjs').then(({ main }) => main()).then(() => process.exit(0)).catch(e => { console.error(e); process.exit(1); })"
+
+echo "Tests passed."

--- a/script/webtest-lib.mjs
+++ b/script/webtest-lib.mjs
@@ -92,8 +92,10 @@ async function browserTests(url, browserName, tests) {
    await browser.close()
 }
 
+const BASE_URL = process.env.BASE_URL || "http://127.0.0.1:8080"
+
 export async function testURL(suffix, tests) {
-   const url = `http://127.0.0.1:8080/${suffix}`
+   const url = `${BASE_URL}/${suffix}`
    await browserTests(url, "chrome", tests)
    await browserTests(url, "firefox", tests)
 }

--- a/website/fluid-org/test.mjs
+++ b/website/fluid-org/test.mjs
@@ -1,0 +1,22 @@
+import { testURL, waitFor, checkTextContent } from "../../script/webtest-lib.mjs"
+
+export const main = async () => {
+   await testURL("", [
+      async page => {
+         await waitFor(page, ".grid-container")
+         await waitFor(page, "h3.title")
+      }
+   ])
+
+   await testURL("faq", [
+      async page => await waitFor(page, ".grid-container")
+   ])
+
+   await testURL("research", [
+      async page => await waitFor(page, ".grid-container")
+   ])
+
+   await testURL("supporters", [
+      async page => await waitFor(page, ".grid-container")
+   ])
+}


### PR DESCRIPTION
## Summary
- Make `BASE_URL` configurable in `webtest-lib.mjs` (defaults to `http://127.0.0.1:8080`)
- Add smoke test for `fluid-org` (checks landing page, FAQ, research, supporters)
- Add `test-deployed-website.sh` for running tests against any URL
- Post-deploy step in `deploy.yml`: waits for GitHub Pages, then runs Puppeteer tests against `https://f.luid.org`

Closes #1427.

## Test plan
- [ ] Verify locally: `BASE_URL=http://localhost:4173 node -e "import('./website/fluid-org/test.mjs').then(({main}) => main())"`
- [ ] Verify in CI: deploy workflow runs post-deploy tests after gh-pages publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)