### PR TITLE
Reinstated install-website for SvelteKit article

### DIFF
--- a/fluid/.gitignore
+++ b/fluid/.gitignore
@@ -7,3 +7,4 @@ dist/
 output/
 output-es/
 artifact/*.tar.gz
+website/

--- a/fluid/package.json
+++ b/fluid/package.json
@@ -19,12 +19,13 @@
   "files": [
     "dist/fluid/shared",
     "dist/fluid/fluid/lib",
-    "web/lib"
+    "web/lib",
+    "website/article"
   ],
   "scripts": {
     "build": "./script/build.sh",
     "build-prod": "BUILD_ENV=prod ./script/build.sh",
-    "build-publish": "yarn build-prod && yarn publish",
+    "build-publish": "yarn build-prod && ./script/stage-website.sh article && yarn publish",
     "build-test": "./script/build-test.sh",
     "bundle-fluid": "./script/bundle-fluid.sh",
     "fluid": "node ./dist/fluid/shared/fluid.mjs",
@@ -68,7 +69,10 @@
   "engines": {
     "node": ">=22"
   },
-  "bin": "./dist/fluid/shared/fluid.mjs",
+  "bin": {
+    "fluid": "./dist/fluid/shared/fluid.mjs",
+    "install-website": "./script/install-website.sh"
+  },
   "svelte": "./web/lib/index.js",
   "exports": {
     ".": "./web/lib/index.js"

--- a/fluid/script/install-website.sh
+++ b/fluid/script/install-website.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+WEBSITE="${1:-article}"
+NPM_ROOT="node_modules/@explorable-viz/fluid"
+SRC="$NPM_ROOT/website/$WEBSITE"
+DEST="website/$WEBSITE"
+
+if [ ! -d "$SRC" ]; then
+   echo "Error: website '$WEBSITE' not found in $NPM_ROOT" >&2
+   echo "Available websites:"
+   ls "$NPM_ROOT/website/" 2>/dev/null || echo "  (none)"
+   exit 1
+fi
+
+if [ -e "$DEST" ]; then
+   echo "Error: $DEST already exists. Remove it first to reinstall." >&2
+   exit 1
+fi
+
+echo "Installing $WEBSITE from $SRC..."
+mkdir -p "$(dirname "$DEST")"
+cp -r "$SRC" "$DEST"
+
+# Recreate symlinks pointing into node_modules
+rm -rf "$DEST/static/fluid/lib"
+ln -s "../../../../$NPM_ROOT/dist/fluid/fluid/lib" "$DEST/static/fluid/lib"
+
+echo ""
+echo "Installed to $DEST. To run:"
+echo "  cd $DEST"
+echo "  yarn install"
+echo "  yarn dev"

--- a/fluid/script/stage-website.sh
+++ b/fluid/script/stage-website.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copy website/article into fluid/ for npm packaging.
+# Run from fluid/ directory before `npm publish`.
+set -e
+
+WEBSITE="${1:-article}"
+SRC="../website/$WEBSITE"
+DEST="website/$WEBSITE"
+
+if [ ! -d "$SRC" ]; then
+   echo "Error: $SRC does not exist" >&2
+   exit 1
+fi
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+rsync -a --exclude=node_modules --exclude=.svelte-kit --exclude=build "$SRC/" "$DEST/"
+
+# Replace symlinks with copies from the source tree
+# static/fluid/lib → fluid standard library
+rm -f "$DEST/static/fluid/lib"
+cp -r fluid/lib "$DEST/static/fluid/lib"
+
+# src/lib/assets/css/styles.css → shared CSS
+rm -f "$DEST/src/lib/assets/css/styles.css"
+cp ../website/src/lib/assets/css/styles.css "$DEST/src/lib/assets/css/styles.css"
+
+echo "Staged $WEBSITE for npm packaging."


### PR DESCRIPTION
## Summary
- `stage-website.sh`: copies article into `fluid/` for npm packaging, resolving symlinks to real files
- `install-website.sh`: copies article from `node_modules` into user project, recreating symlinks to Fluid lib
- Added `install-website` bin entry so users can run `npx install-website article`
- `build-publish` now runs `stage-website.sh` before `npm publish`
- `fluid/.gitignore` updated to exclude staged `website/`

Closes #1492.

## Test plan
- [x] `stage-website.sh` produces correct output (symlinks resolved, no node_modules)
- [x] `install-website.sh` copies to `website/article` with symlink to `node_modules/.../lib`
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)