### PR TITLE
Automatic version bump and git tag on npm publish

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ From the monorepo root:
 yarn workspace @explorable-viz/fluid build-publish
 ```
 
-This builds in production mode, stages the `article` website for packaging, and publishes to npm. The package version in `fluid/package.json` should be bumped before publishing — it tracks the milestone version (e.g. `0.12.x` for milestone `fluid 0.12`).
+This bumps the patch version (via `npm version patch`), builds in production mode, stages the `article` website, publishes to npm, and pushes the version tag. Version tracks milestone (e.g. `0.12.x` for milestone `fluid 0.12`).
 
 ## VS Code
 

--- a/fluid/package.json
+++ b/fluid/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "./script/build.sh",
     "build-prod": "BUILD_ENV=prod ./script/build.sh",
-    "build-publish": "yarn build-prod && ./script/stage-website.sh article && npm publish --access public",
+    "build-publish": "npm version patch && yarn build-prod && ./script/stage-website.sh article && npm publish --access public && git push && git push --tags",
     "build-test": "./script/build-test.sh",
     "bundle-fluid": "./script/bundle-fluid.sh",
     "fluid": "node ./dist/fluid/shared/fluid.mjs",


### PR DESCRIPTION
## Summary
- `build-publish` now uses `npm version patch` to bump version and create git tag
- Pushes commit and tag after publish
- No more manual version editing in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)