### PR TITLE
Cross-selection test for MatrixView convolution

### DIFF
--- a/fluid/script/webtest-lib.mjs
+++ b/fluid/script/webtest-lib.mjs
@@ -25,10 +25,10 @@ async function launchBrowser(browserName) {
    })
 }
 
-export async function waitFor(page, selector) {
-   log(`Waiting for ${selector}`)
+export async function waitFor(page, selector, { visible = true } = {}) {
+   log(`Waiting for ${selector}${visible ? "" : " (any)"}`)
    try {
-      await page.waitForSelector(selector, { timeout: TIMEOUT, visible: true })
+      await page.waitForSelector(selector, { timeout: TIMEOUT, visible })
       log("-> found")
       testOutcome(true, `${selector}: exists`)
    } catch (e) {

--- a/website/article/test.mjs
+++ b/website/article/test.mjs
@@ -16,10 +16,19 @@ export const main = async () => {
          await waitFor(page, "#fig-output .title-text")
 
          const cell = "#fig-output .matrix-cell"
+         await checkCount(page, "#fig-output .matrix-cell[class*='selected']", 0)
          await page.hover(cell)
          await checkAttributeContains(page, cell, "class", "selected-primary-transient")
          await click(page, cell)
          await checkAttributeContains(page, cell, "class", "selected-primary-persistent")
+      },
+      async page => {
+         await waitFor(page, "svg#fig-output")
+         await clickToggle(page)
+         await waitFor(page, "#fig-input .matrix-cell")
+         await checkCount(page, "#fig-input .matrix-cell[class*='selected']", 0)
+         await dispatchMouseDown(page, "#fig-output .matrix-cell")
+         await checkCountAtLeast(page, "#fig-input .matrix-cell.selected-primary-persistent", 1)
       }
    ])
 


### PR DESCRIPTION
Closes #1520.

- Toggle data pane, mousedown output cell, verify input cells get selected-primary-persistent
- Assert zero selections before interaction in both test functions
- Separate test functions for clean page state between interaction tests
- waitFor visible option, dispatchMouseDown, checkCountAtLeast helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)