### PR TITLE
Expose HEADLESS env var for local Puppeteer debugging (#1171)

### DIFF
--- a/fluid/script/webtest-lib.mjs
+++ b/fluid/script/webtest-lib.mjs
@@ -2,7 +2,7 @@ import puppeteer from "puppeteer"
 
 const TIMEOUT = 60000
 const LOGGING = true
-const HEADLESS = true
+const HEADLESS = process.env.HEADLESS !== "false"
 const DESKTOP = { width: 1200, height: 800, deviceScaleFactor: 1.0 }
 const MOBILE = { width: 390, height: 844, deviceScaleFactor: 2.0, isMobile: true }
 const VIEWPORT = process.env.MOBILE ? MOBILE : DESKTOP


### PR DESCRIPTION
## Summary

- Mirrors existing `MOBILE` env var pattern in `webtest-lib.mjs`
- CI stays headless by default; `HEADLESS=false yarn test` opens a visible browser for local debugging

Closes #1171.

## Test plan

- [ ] Default run (no env var): tests pass headless — verified locally
- [ ] `HEADLESS=false`: browser GUI appears — not verified locally (no GUI available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)