### PR TITLE
Filter right-clicks from selection handlers (#1032)

### DIFF
--- a/fluid/script/webtest-lib.mjs
+++ b/fluid/script/webtest-lib.mjs
@@ -47,11 +47,11 @@ export async function click(page, selector) {
    testOutcome(true, `${selector}: click`)
 }
 
-export async function dispatchMouseDown(page, selector) {
-   await page.evaluate(sel => {
-      document.querySelector(sel).dispatchEvent(new MouseEvent('mousedown', { bubbles: true }))
-   }, selector)
-   testOutcome(true, `${selector}: mousedown`)
+export async function dispatchMouseDown(page, selector, button = 0) {
+   await page.evaluate((sel, btn) => {
+      document.querySelector(sel).dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: btn }))
+   }, selector, button)
+   testOutcome(true, `${selector}: mousedown (button=${button})`)
 }
 
 export async function checkAttribute(page, selector, attr, expected) {

--- a/fluid/src/App/View/LineChart.purs
+++ b/fluid/src/App/View/LineChart.purs
@@ -22,7 +22,6 @@ import DataType (f_plots)
 import Effect (Effect, foreachE)
 import Lattice ((∨), (∧))
 import Util (type (×), Endo, definitely', init, nonEmpty, tail, zipWith, (!), (×))
-import Web.Event.EventTarget (eventListener)
 
 newtype LineChart = LineChart
    { size :: Dimensions (Selectable Int)
@@ -64,11 +63,10 @@ instance Viewable LineChart Unit where
    setSelection :: Unit -> LineChart -> Select -> D3.Selection -> Effect Unit
    setSelection _ (LineChart { plots }) redraw rootElement = do
       points <- rootElement # selectAll ".linechart-point"
-      listener <- eventListener (redraw <<< uncurry pointSel <<< selectionEventData')
 
       foreachE points \point -> do
          point' <- datum point
-         point # setAttrs (pointAttrs point') >>= registerMouseListeners listener
+         point # setAttrs (pointAttrs point') >>= registerMouseListeners (redraw <<< uncurry pointSel <<< selectionEventData')
       segments <- rootElement # selectAll ".linechart-segment"
       foreachE segments \segment -> do
          segment' <- datum segment

--- a/fluid/src/App/View/Link.purs
+++ b/fluid/src/App/View/Link.purs
@@ -18,7 +18,6 @@ import Lattice (bot, join)
 import Partial.Unsafe (unsafePartial)
 import Util ((×))
 import Val (BaseVal(..), Val(..))
-import Web.Event.EventTarget (eventListener)
 
 data Link = Link (Val (SelStates 𝕊)) (Selectable String)
 
@@ -35,8 +34,7 @@ instance Viewable Link Unit where
 
    setSelection :: Unit -> Link -> Select -> D3.Selection -> Effect Unit
    setSelection _ link redraw rootElement = do
-      listener <- eventListener (redraw <<< uncurry selLink <<< selectionEventData')
-      rootElement # setStyles (textAttrs link) >>= registerMouseListeners listener
+      rootElement # setStyles (textAttrs link) >>= registerMouseListeners (redraw <<< uncurry selLink <<< selectionEventData')
       where
       selLink :: ViewSelSetter Link
       selLink _ δv = unsafePartial $ case _ of

--- a/fluid/src/App/View/MatrixView.purs
+++ b/fluid/src/App/View/MatrixView.purs
@@ -16,7 +16,6 @@ import Effect (Effect, foreachE)
 import Primitive (int, unpack)
 import Util ((!), (×))
 import Val (Array2, MatrixDim(..), MatrixRep(..))
-import Web.Event.EventTarget (eventListener)
 
 --  (Rendered) matrices are required to have element type Int for now.
 type IntMatrix = { cells :: Array2 (Selectable Int), i :: Int, j :: Int }
@@ -126,14 +125,13 @@ instance Viewable MatrixView Unit where
 
 setCellSelection :: IntMatrix -> Select -> D3.Selection -> Effect Unit
 setCellSelection matrix select rootElement = do
-   listener <- eventListener (select <<< uncurry element <<< selectionEventData')
    cells <- D3.selectAll ".matrix-cell" rootElement
    foreachE cells \cell -> do
       coord :: MatrixCellCoordinate <- D3.datum cell
       let selState = snd (matrix.cells ! coord.i ! coord.j)
       void $ D3.classed selClasses false cell
       void $ D3.classed (selClassesFor selState) true cell
-      registerMouseListeners listener cell
+      registerMouseListeners (select <<< uncurry element <<< selectionEventData') cell
    texts <- D3.selectAll ".matrix-cell-text" rootElement
    foreachE texts \text -> do
       coord :: MatrixCellCoordinate <- D3.datum text

--- a/fluid/src/App/View/ScatterPlot.purs
+++ b/fluid/src/App/View/ScatterPlot.purs
@@ -20,7 +20,6 @@ import Effect (Effect, foreachE)
 import Foreign.Object (fromFoldable)
 import Lattice ((∨))
 import Util (Endo, type (×), (!))
-import Web.Event.EventTarget (eventListener)
 
 newtype ScatterPlot = ScatterPlot
    { caption :: Selectable String
@@ -108,7 +107,6 @@ instance Viewable ScatterPlot Unit where
       pure rootElement
 
    setSelection _ (ScatterPlot { points }) select rootElement = do
-      listener <- eventListener (select <<< uncurry scatterPlotPoint <<< selectionEventData')
       pointEls <- D3.selectAll ".scatterplot-point" rootElement
       foreachE pointEls \pointEl -> do
          idx :: PointIndex <- D3.datum pointEl
@@ -118,7 +116,7 @@ instance Viewable ScatterPlot Unit where
          void $ D3.classed selClasses false pointEl
          void $ D3.classed (selClassesFor sel) true pointEl
          void $ D3.attrs pointEl (fromFoldable (pointAttrs points idx))
-         registerMouseListeners listener pointEl
+         registerMouseListeners (select <<< uncurry scatterPlotPoint <<< selectionEventData') pointEl
 
 scatterPlotPoint :: ViewSelSetter PointIndex
 scatterPlotPoint { i } = scatterPoint i >>> scatterPlot

--- a/fluid/src/App/View/Segment.purs
+++ b/fluid/src/App/View/Segment.purs
@@ -13,7 +13,6 @@ import Data.Newtype (class Newtype)
 import Data.Tuple (uncurry)
 import Effect (Effect)
 import Util (Endo)
-import Web.Event.EventTarget (eventListener)
 
 newtype Segment = Segment
    { y :: Selectable String -- overloading of y here and in SegmentContext needs fixing
@@ -48,8 +47,7 @@ instance Viewable Segment SegmentContext where
 
    setSelection :: SegmentContext -> Segment -> Select -> D3.Selection -> Effect Unit
    setSelection { y_index } (Segment { z }) select segment = do
-      listener <- eventListener (select <<< uncurry (\_ -> nthSegment y_index) <<< selectionEventData')
-      segment # setAttrs attrs >>= registerMouseListeners listener
+      segment # setAttrs attrs >>= registerMouseListeners (select <<< uncurry (\_ -> nthSegment y_index) <<< selectionEventData')
       where
       attrs :: Attrs
       attrs =

--- a/fluid/src/App/View/TableView.purs
+++ b/fluid/src/App/View/TableView.purs
@@ -21,7 +21,6 @@ import Effect (Effect, foreachE)
 import Util (type (×), absurd, error, length, nonEmpty, (!), (×))
 import Util.Map (get, keys)
 import Val (Array2, BaseVal(..), Val(..))
-import Web.Event.EventTarget (eventListener)
 
 type Record' = Array (Val (SelStates 𝕊)) -- somewhat anomalous, as elsewhere we have Selectables
 
@@ -80,14 +79,13 @@ instance Viewable TableView Unit where
    setSelection :: Unit -> TableView -> Select -> D3.Selection -> Effect Unit
    setSelection _ (TableView { title, colNames, rows, rowFilter }) redraw rootElement = do
       cells <- rootElement # selectAll ".table-cell"
-      listener <- eventListener (redraw <<< uncurry tableViewSelSetter <<< selectionEventData')
       foreachE cells \cell -> do
          { i, j, colName } :: CellIndex <- datum cell
          if i == -1 || j == -1 then pure unit
          else do
             cell # classed selClasses false
                >>= classed (cell_selClassesFor colName (rows ! i ! j # \(Val α _ _) -> α)) true
-               >>= registerMouseListeners listener
+               >>= registerMouseListeners (redraw <<< uncurry tableViewSelSetter <<< selectionEventData')
          void $ cell # setStyles
             [ "border-right" ↦ border Faint (hasRightBorder i j) (isNothing $ column_visibleSucc j)
             , "border-bottom" ↦ border Transparent (hasBottomBorder i j) (i == length rows - 1)

--- a/fluid/src/App/View/Text.purs
+++ b/fluid/src/App/View/Text.purs
@@ -11,7 +11,6 @@ import Bind ((↦))
 import Data.Newtype (class Newtype, unwrap)
 import Data.Tuple (uncurry)
 import Effect (Effect)
-import Web.Event.EventTarget (eventListener)
 
 class Textual a where
    getText :: a -> Selectable String
@@ -28,8 +27,7 @@ instance Viewable Text Unit where
 
    setSelection :: Unit -> Text -> Select -> D3.Selection -> Effect Unit
    setSelection _ text redraw rootElement = do
-      listener <- eventListener (redraw <<< uncurry textSelector <<< selectionEventData')
-      rootElement # setStyles (textAttrs text) >>= registerMouseListeners listener
+      rootElement # setStyles (textAttrs text) >>= registerMouseListeners (redraw <<< uncurry textSelector <<< selectionEventData')
       where
       textSelector :: ViewSelSetter Text
       textSelector _ = identity

--- a/fluid/src/App/View/Util.js
+++ b/fluid/src/App/View/Util.js
@@ -1,0 +1,5 @@
+"use strict"
+
+export function mouseButton (event) {
+   return event.button
+}

--- a/fluid/src/App/View/Util.purs
+++ b/fluid/src/App/View/Util.purs
@@ -16,7 +16,7 @@ import Data.Maybe (Maybe)
 import Data.Set (Set)
 import Data.Tuple (fst, snd)
 import Dict (Dict)
-import Effect (Effect, foreachE)
+import Effect (Effect)
 import File (Folder)
 import Graph (DVertex, Vertex, Query)
 import Lattice (𝔹, Raw, (∨))
@@ -25,8 +25,8 @@ import Util (type (×), Endo, check, (×))
 import Util.Map (toUnfoldable, values)
 import Util.Set (size)
 import Val (Env, Val)
-import Web.Event.Event (EventType(..))
-import Web.Event.EventTarget (EventListener)
+import Web.Event.Event (Event, EventType(..))
+import Web.Event.EventTarget (eventListener)
 
 type HTMLId = String
 type Redraw = Endo Fig -> Effect Unit
@@ -93,10 +93,15 @@ drawView :: RendererSpec View -> (SetSel (Val (SelStates 𝔹)) -> Effect Unit) 
 drawView rSpec@{ view: vw } redraw =
    unpack vw (\view -> draw uiHelpers (rSpec { view = view }) redraw)
 
-registerMouseListeners :: EventListener -> D3.Selection -> Effect Unit
-registerMouseListeners redraw element = do
-   foreachE [ "mousedown", "mouseenter", "mouseleave" ] \ev ->
-      void $ element # on (EventType ev) redraw
+foreign import mouseButton :: Event -> Int
+
+registerMouseListeners :: (Event -> Effect Unit) -> D3.Selection -> Effect Unit
+registerMouseListeners handler element = do
+   click <- eventListener \event -> when (mouseButton event == 0) (handler event)
+   hover <- eventListener handler
+   void $ element # on (EventType "mousedown") click
+   void $ element # on (EventType "mouseenter") hover
+   void $ element # on (EventType "mouseleave") hover
 
 -- Heavily curried type isn't convenient for FFI
 type RendererSpec a =

--- a/website/article/test.mjs
+++ b/website/article/test.mjs
@@ -56,6 +56,13 @@ export const main = async () => {
 
          const caption = "div#fig-input-renewables > div.table-caption"
          await checkTextContent(page, caption, "renewables (40 of 240 × 5 of 5)")
+      },
+      async page => {
+         await waitFor(page, "svg")
+         const point = "#fig .scatterplot-point"
+         await waitFor(page, point)
+         await dispatchMouseDown(page, point, 2)
+         await checkCount(page, "#fig .scatterplot-point.selected-primary-persistent", 0)
       }
    ])
 


### PR DESCRIPTION
## Summary

- Previously any \`mousedown\` — including right-click to open the browser context menu — toggled persistent selection on the clicked element
- Adds a \`mouseButton\` FFI and changes \`registerMouseListeners\` to take an \`Event -> Effect Unit\` handler (rather than a pre-built \`EventListener\`), so the mousedown wrapper can filter \`button !== 0\`
- Updates all 8 call sites (ScatterPlot, LineChart, MatrixView, Segment, Text, Link, TableView) to pass the handler directly
- Adds \`button\` parameter to \`dispatchMouseDown\` test helper (default 0, backward-compatible)

Closes #1032.

## Test plan

- [x] New puppeteer test case in energy-scatter: \`dispatchMouseDown(page, point, 2)\` then verify \`.scatterplot-point.selected-primary-persistent\` count is 0
- [x] Existing tests still pass (Chrome + Firefox on all article pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)