### PR TITLE
Hover-hint on data pane toggle when there is pending selection (#1013)

### DIFF
--- a/fluid/web/lib/DataPane.svelte
+++ b/fluid/web/lib/DataPane.svelte
@@ -43,4 +43,8 @@
 	.toggle-button:hover {
 		color: #999999;
 	}
+
+	:global(.data-pane-hidden:has(.data-pane .selected-primary-persistent)) .toggle-button {
+		color: #999999;
+	}
 </style>

--- a/website/article/test.mjs
+++ b/website/article/test.mjs
@@ -61,6 +61,16 @@ export const main = async () => {
          await waitFor(page, "svg")
          const point = "#fig .scatterplot-point"
          await waitFor(page, point)
+         const toggle = ".data-pane-button.toggle-button"
+         await checkComputedStyle(page, toggle, "color", "rgb(204, 204, 204)")
+         await click(page, point)
+         await waitFor(page, "#fig-data-pane .selected-primary-persistent", { visible: false })
+         await checkComputedStyle(page, toggle, "color", "rgb(153, 153, 153)")
+      },
+      async page => {
+         await waitFor(page, "svg")
+         const point = "#fig .scatterplot-point"
+         await waitFor(page, point)
          await dispatchMouseDown(page, point, 2)
          await checkCount(page, "#fig .scatterplot-point.selected-primary-persistent", 0)
       }


### PR DESCRIPTION
## Summary

- When the data pane is collapsed and an output selection has propagated persistent highlighting into (hidden) input cells, the toggle button adopts its hover colour to signal "there is data to explore"
- Pure-CSS \`:has()\` rule in \`DataPane.svelte\` — no reactive plumbing needed between Fluid's runtime and the Svelte host

Closes #1013.

## Test plan

- [x] New puppeteer test case in energy-scatter: verify toggle colour is \`rgb(204, 204, 204)\` on load, then \`rgb(153, 153, 153)\` after clicking a scatter point (with pane still hidden)
- [x] Existing tests still pass on Chrome + Firefox
- [ ] Manual: visit \`/energy-scatter\`, click a scatter point, confirm toggle button icon visibly darkens

🤖 Generated with [Claude Code](https://claude.com/claude-code)