### PR TITLE
Fix check-project-integrity: update org to fluid-org

### DIFF
--- a/script/check-project-integrity.sh
+++ b/script/check-project-integrity.sh
@@ -2,14 +2,14 @@
 set -e
 
 REPO="${1:-fluid}"
-ORG="explorable-viz"
+ORG="fluid-org"
 ERRORS=0
 
 echo "Checking project integrity for $ORG/$REPO..."
 
 ALL_ITEMS=$(gh api graphql --paginate -f query='
   query($endCursor: String) {
-    organization(login: "explorable-viz") {
+    organization(login: "fluid-org") {
       projectV2(number: 1) {
         items(first: 100, after: $endCursor) {
           pageInfo { hasNextPage endCursor }


### PR DESCRIPTION
## Summary
- The `check-project-integrity` workflow was failing because `script/check-project-integrity.sh` still referenced the old `explorable-viz` org. Updated both the `ORG` variable and the GraphQL `organization(login: ...)` argument to `fluid-org`.

## Test plan
- [ ] Trigger workflow_dispatch on `check-project-integrity` after merge and confirm it succeeds