### PR TITLE
Stmt/Block scaffold in SExpr (#1530)

### DIFF
--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -27,7 +27,7 @@ import Parsing.Expr (Assoc(..), OperatorTable, buildExprParser)
 import Parsing.Indent (runIndent, sameOrIndented, withPos)
 import Parsing.String (eof, satisfy)
 import Primitive.Parse (OpDef(..), OpType(..), Fixity(..), opDefs)
-import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
+import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), Module(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs, singletonBlock)
 import Util (type (+), type (×), error, nonEmpty, (×))
 
 pattern :: Parser Pattern
@@ -91,7 +91,7 @@ recDefs = many1 recDef
       ps <- commas1 pattern
       delim ')'
       e <- block expr
-      pure $ p × Clause (ps × e)
+      pure $ p × Clause (ps × singletonBlock e)
 
 expr :: Parser (Raw Expr)
 expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
@@ -243,7 +243,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
                delim ':'
                e <- opTree
                delim ';'
-               pure $ p × Clause (ps × e)
+               pure $ p × Clause (ps × singletonBlock e)
 
          lambda :: Parser (Raw Expr)
          lambda = context "lambda" do
@@ -251,7 +251,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
             ps <- commas1 pattern
             delim ':'
             e <- opTree
-            pure $ Lambda (Clauses (nonEmpty (Clause (ps × e) : Nil)))
+            pure $ Lambda (Clauses (nonEmpty (Clause (ps × singletonBlock e) : Nil)))
 
          var :: Parser (Raw Expr)
          var = variable <#> Var

--- a/fluid/src/Pretty.purs
+++ b/fluid/src/Pretty.purs
@@ -17,7 +17,7 @@ import Lattice (class BotOf, class MeetSemilattice, class Neg, botOf, symmetricD
 import Pretty.Doc (Doc, empty, expr, indent, inlOrMul, line, render, stmt, stmtOrExpr, text, (<++>), (<+>), (</>))
 import Pretty.Util (block, braces, brackets, hsep, matrix, number, pair, parens, record, sep', string, vsep)
 import Primitive.Parse (getPrec)
-import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs)
+import SExpr (Branch, Clause(..), Clauses(..), DictEntry(..), Expr(..), ListRest(..), ListRestPattern(..), ParagraphElem(..), Pattern(..), Qualifier(..), RecDefs, VarDef(..), VarDefs, runBlock)
 import Util (type (×), error, isEmpty, (×))
 import Util.Map (toUnfoldable)
 import Util.Pair (Pair(..))
@@ -205,7 +205,7 @@ instance Ann a => Pretty (VarDefs a) where
    pretty ds = sep' (stmtOrExpr line (text " ")) (toList (pretty <$> ds))
 
 instance Ann a => Pretty (Clause a) where
-   pretty (Clause (ps × e)) = lambda (toList ps) e
+   pretty (Clause (ps × b)) = lambda (toList ps) (runBlock b)
 
 instance Ann a => Pretty (Clauses a) where
    pretty (Clauses cs) = pretty (head cs) -- TODO: head ?
@@ -214,11 +214,11 @@ instance Ann a => Pretty (RecDefs a) where
    pretty bs = sep' (stmtOrExpr line (text " ")) (toList (pretty <$> bs))
 
 instance Ann a => Pretty (Branch a) where
-   pretty (v × Clause (ps × e)) =
+   pretty (v × Clause (ps × b)) =
       text "def"
          <+> text v
          <> parens (prettyList (toList ps))
-         <> block (pretty e)
+         <> block (pretty (runBlock b))
 
 instance Ann a => Pretty (DictEntry a × Expr a) where
    pretty (k × v) =

--- a/fluid/src/SExpr.purs
+++ b/fluid/src/SExpr.purs
@@ -114,7 +114,21 @@ subpatts (Right (PListVar _)) = Nil
 subpatts (Right PListEnd) = Nil
 subpatts (Right (PListNext p o)) = Left p : Right o : Nil
 
-newtype Clause a = Clause (NonEmptyList Pattern × Expr a)
+-- A statement is, for now, just an expression. Future variants (Return, Assign,
+-- Pass, mutual regions) will be added incrementally per the PurePy 0.9 sync (#1530).
+newtype Stmt a = ExprStmt (Expr a)
+-- A block is a non-empty sequence of statements; currently always a singleton.
+newtype Block a = Block (NonEmptyList (Stmt a))
+
+singletonBlock :: forall a. Expr a -> Block a
+singletonBlock e = Block (NonEmptyList (ExprStmt e :| Nil))
+
+-- Partial: assumes a singleton ExprStmt block. Holds while statements are only ExprStmt.
+runBlock :: forall a. Block a -> Expr a
+runBlock (Block (NonEmptyList (ExprStmt e :| Nil))) = e
+runBlock _ = error "runBlock: non-singleton block"
+
+newtype Clause a = Clause (NonEmptyList Pattern × Block a)
 
 type Branch a = Var × Clause a
 newtype Clauses a = Clauses (NonEmptyList (Clause a))
@@ -197,7 +211,7 @@ moduleFwd (Module ds) = E.Module <$> traverse varDefOrRecDefsFwd (join (flatten 
 -- in evaluation.
 varDefFwd :: forall a m. MonadError Error m => BoundedLattice a => VarDef a -> m (E.VarDef a)
 varDefFwd (VarDef p s) =
-   E.VarDef <$> desug (Clauses (singleton (Clause (singleton p × Dictionary top Nil)))) <*> desug s
+   E.VarDef <$> desug (Clauses (singleton (Clause (singleton p × singletonBlock (Dictionary top Nil))))) <*> desug s
 
 -- VarDefs
 varDefsFwd :: forall a m. MonadError Error m => BoundedLattice a => VarDefs a × Expr a -> m (E.Expr a)
@@ -316,7 +330,7 @@ exprFwd (BinaryApp s1 op s2) =
 exprFwd (UnaryPrefixApp op s) =
    E.App (E.Op op) <$> desug s
 exprFwd (MatchAs s μ) =
-   E.App <$> (E.Lambda top <$> desug (Clauses (Clause <$> first singleton <$> μ))) <*> desug s
+   E.App <$> (E.Lambda top <$> desug (Clauses ((Clause <<< second singletonBlock) <$> first singleton <$> μ))) <*> desug s
 exprFwd (IfElse sss s) =
    ifElseFwd (sss × s)
 exprFwd (Paragraph elems) =
@@ -368,7 +382,7 @@ exprBwd (E.App (E.Op _) e) (UnaryPrefixApp op s) =
    UnaryPrefixApp op (desugBwd e s)
 exprBwd (E.App (E.Lambda _ σ) e) (MatchAs s μ) =
    MatchAs (desugBwd e s)
-      (first head <$> unwrap <$> unwrap (desugBwd σ (Clauses (Clause <$> first singleton <$> μ))))
+      (first head <<< second runBlock <$> unwrap <$> unwrap (desugBwd σ (Clauses ((Clause <<< second singletonBlock) <$> first singleton <$> μ))))
 exprBwd e@(E.App (E.Lambda _ (ElimConstr _)) _) (IfElse sss s) =
    let sss' × s' = ifElseBwd e (sss × s) in IfElse sss' s'
 exprBwd (E.Constr _ c (es : Nil)) (Paragraph elems) | c == cParagraph =
@@ -466,14 +480,14 @@ toClausesStateFwd :: forall a. Clauses a -> ClausesState' a
 toClausesStateFwd (Clauses μ) = toList μ <#> toClauseStateFwd
    where
    toClauseStateFwd :: Clause a -> ClauseState' a
-   toClauseStateFwd (Clause (NonEmptyList (p :| π) × s)) = (Left p : Nil) × π × s
+   toClauseStateFwd (Clause (NonEmptyList (p :| π) × b)) = (Left p : Nil) × π × runBlock b
 
 toClausesStateBwd :: forall a. ClausesState' a -> Clauses a
 toClausesStateBwd Nil = error (shapeMismatch unit)
 toClausesStateBwd (k : ks) = Clauses (NonEmptyList (k :| ks) <#> toClauseStateBwd)
    where
    toClauseStateBwd :: ClauseState' a -> Clause a
-   toClauseStateBwd ((Left p : Nil) × π × s) = Clause (NonEmptyList (p :| π) × s)
+   toClauseStateBwd ((Left p : Nil) × π × s) = Clause (NonEmptyList (p :| π) × singletonBlock s)
    toClauseStateBwd _ = error (shapeMismatch unit)
 
 -- Like ClauseState but for curried functions; extra component π' stores remaining top-level patterns.
@@ -672,9 +686,12 @@ orElseBwd (π0 × s) ks = case π0 of
 -- ======================
 -- boilerplate
 -- ======================
+derive instance Newtype (Block a) _
 derive instance Newtype (Clause a) _
 derive instance Newtype (Clauses a) _
 derive instance Newtype (RecDef a) _
+derive instance Functor Stmt
+derive instance Functor Block
 derive instance Functor Clause
 derive instance Functor Clauses
 derive instance Functor DictEntry
@@ -689,7 +706,7 @@ instance Functor Module where
       where
       mapDefs :: forall a b. (a -> b) -> VarDefs a + RecDefs a -> VarDefs b + RecDefs b
       mapDefs g (Left ds) = Left $ map g <$> ds
-      mapDefs g (Right ds) = Right $ (\(x × Clause (π × s)) -> x × Clause (π × (g <$> s))) <$> ds
+      mapDefs g (Right ds) = Right $ (\(x × Clause (π × b)) -> x × Clause (π × (g <$> b))) <$> ds
 
 instance JoinSemilattice a => JoinSemilattice (Expr a) where
    join _ = error unimplemented
@@ -717,6 +734,16 @@ instance Show Pattern where
 derive instance Eq ListRestPattern
 derive instance Generic ListRestPattern _
 instance Show ListRestPattern where
+   show c = genericShow c
+
+derive instance Eq a => Eq (Stmt a)
+derive instance Generic (Stmt a) _
+instance Show a => Show (Stmt a) where
+   show c = genericShow c
+
+derive instance Eq a => Eq (Block a)
+derive instance Generic (Block a) _
+instance Show a => Show (Block a) where
    show c = genericShow c
 
 derive instance Eq a => Eq (Clause a)


### PR DESCRIPTION
First step toward PurePy 0.9 syntactic alignment per #1530.

Introduces `Stmt a = ExprStmt (Expr a)` and `Block a = NonEmptyList (Stmt a)` in `SExpr`, and reroutes `Clause` to hold a `Block` rather than an `Expr`. The parser produces singleton blocks; desugaring unwraps them via `runBlock`. No behavioural change — all 103 tests pass.

The seam is now in place so subsequent commits can add `Return`, `Assign`, and mutual-region statement variants without further churn to the surrounding pipeline.

## Test plan
- [x] `yarn build` clean
- [x] `yarn test` — 103/103 pass