### PR TITLE
Pythonic ternary conditional + split IfElse into Stmt/Expr (#1415)

### DIFF
--- a/fluid/fluid/lib/graphics.fld
+++ b/fluid/fluid/lib/graphics.fld
@@ -166,12 +166,8 @@ def axis(orient, x, start, end):
   def last_tick: ceiling_to_nearest(end, tick_sp)
   def n: floor((end - first_tick) / tick_sp) + 1
   def ys: iterate(n, (+)(tick_sp), first_tick)
-  def ys:
-    if first_tick > start: start :| ys
-    else: ys
-  def ys:
-    if last_tick > end: concat2(ys, [last_tick])
-    else: ys
+  def ys: start :| ys if first_tick > start else ys
+  def ys: concat2(ys, [last_tick]) if last_tick > end else ys
   def ps: map(mk_point(orient, x), ys)
   def ax:
     Group([

--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -19,7 +19,7 @@ import Data.Traversable (foldl, foldr)
 import DataType (cPair)
 import Lattice (Raw)
 import Parse.Number (float, integer)
-import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace, withPos')
+import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace, withPosReset)
 import Parsing (ParseError(..), Position(..), consume, fail, runParserT)
 import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
 import Parsing.Expr (Assoc(..), Operator(..)) as P
@@ -152,13 +152,13 @@ expr = context "expr" $ matchAs <|> def <|> ternary <?> "expression"
       funDef <|> valDef
       where
       funDef :: Parser (Raw Expr)
-      funDef = context "funDef" $ withPos' do
+      funDef = context "funDef" $ withPosReset do
          ds <- recDefs
          ss <- many1 (align stmt)
          pure $ LetRec ds (Block ss)
 
       valDef :: Parser (Raw Expr)
-      valDef = context "valDef" $ withPos' do
+      valDef = context "valDef" $ withPosReset do
          ds <- varDefs
          ss <- many1 (align stmt)
          pure $ Let ds (Block ss)

--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -103,7 +103,7 @@ expr :: Parser (Raw Expr)
 expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
    where
    ternary :: Parser (Raw Expr)
-   ternary = do
+   ternary = defer \_ -> do
       e1 <- opTree
       option e1 $ try do
          reserved "if"
@@ -201,14 +201,14 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
             dproject :: Parser (Raw Expr)
             dproject = do
                delim '['
-               k <- opTree
+               k <- ternary
                close ']'
                chain (DProject e k)
 
             app :: Parser (Raw Expr)
             app = do
                delim '('
-               ps <- commas opTree
+               ps <- commas ternary
                close ')'
                case e of
                   (Constr a c es) -> chain (Constr a c (es <> ps <> Nil))
@@ -235,20 +235,20 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
          letExpr :: Parser (Raw Expr)
          letExpr = context "letExpr" do
             ds <- many1 varDef
-            e <- opTree
+            e <- ternary
             pure $ Let ds (returns e)
             where
             varDef :: Parser (Raw VarDef)
             varDef = do
                p <- try (reserved "def" *> pattern <* delim ':')
-               e <- opTree
+               e <- ternary
                delim ';'
                pure $ VarDef p e
 
          letRecExpr :: Parser (Raw Expr)
          letRecExpr = context "letRecExpr" do
             ds <- many1 recDef
-            e <- opTree
+            e <- ternary
             pure $ LetRec ds (returns e)
             where
             recDef :: Parser (Raw Branch)
@@ -257,7 +257,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
                ps <- commas1 pattern
                delim ')'
                delim ':'
-               e <- opTree
+               e <- ternary
                delim ';'
                pure $ p × Clause (ps × returns e)
 
@@ -266,7 +266,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
             reserved "lambda"
             ps <- commas1 pattern
             delim ':'
-            e <- opTree
+            e <- ternary
             pure $ Lambda (Clauses (nonEmpty (Clause (ps × returns e) : Nil)))
 
          var :: Parser (Raw Expr)
@@ -315,7 +315,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
 
             where
             exprKey :: Parser (Raw DictEntry)
-            exprKey = defer \_ -> brackets opTree <#> ExprKey
+            exprKey = defer \_ -> brackets ternary <#> ExprKey
 
             varKey :: Parser (Raw DictEntry)
             varKey = variable <#> VarKey unit
@@ -323,7 +323,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
          matrix :: Parser (Raw Expr)
          matrix = context "matrix" do
             delim "[|"
-            e <- opTree
+            e <- ternary
             reserved "for"
             delim '('
             x <- variable
@@ -331,7 +331,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
             y <- variable
             delim ')'
             reserved "in"
-            e' <- opTree
+            e' <- ternary
             delim "|]"
             pure $ Matrix unit e (x × y) e'
 
@@ -343,11 +343,11 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
                     close ']'
                     pure $ ListEmpty unit
                , do
-                    e <- opTree
+                    e <- ternary
                     choice
                        [ context "listNonEmpty" do
                             delim ','
-                            rest <- trailingCommas opTree
+                            rest <- trailingCommas ternary
                             close ']'
                             pure $ ListNonEmpty unit e (foldr (Next unit) (End unit) rest)
                        , do
@@ -355,7 +355,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
                             pure $ ListNonEmpty unit e (End unit)
                        , context "listEnum" do
                             delim ".."
-                            e' <- opTree
+                            e' <- ternary
                             close ']'
                             pure $ ListEnum e e'
 
@@ -393,14 +393,14 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
                     op <- try (operator <* close ')')
                     pure $ Op op
                , do
-                    e <- opTree
+                    e <- ternary
                     choice
                        [ do
                             close ')'
                             pure e
                        , do
                             delim ','
-                            e' <- opTree
+                            e' <- ternary
                             close ')'
                             pure $ Constr unit cPair (e : e' : Nil)
                        , fail "Expected `)` or `,` after `(expr`"

--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -19,7 +19,7 @@ import Data.Traversable (foldl, foldr)
 import DataType (cPair)
 import Lattice (Raw)
 import Parse.Number (float, integer)
-import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace)
+import Parse.Parser (Parser, align, block, braces, brackets, close, commas, commas1, constructor, context, delim, fields, lexeme, operator, parens, reserved, reservedOperator, stringLiteral, trailingCommas, variable, whitespace, withPos')
 import Parsing (ParseError(..), Position(..), consume, fail, runParserT)
 import Parsing.Combinators (choice, many, many1, option, sepBy1, try, (<?>))
 import Parsing.Expr (Assoc(..), Operator(..)) as P
@@ -83,7 +83,26 @@ varDefs = many1 varDef
       pure $ VarDef p e
 
 stmt :: Parser (Raw Stmt)
-stmt = defer \_ -> (reserved "return" *> expr <#> Return) <|> (Return <$> expr)
+stmt = defer \_ -> ifStmt <|> (reserved "return" *> expr <#> Return) <|> (Return <$> expr)
+
+ifStmt :: Parser (Raw Stmt)
+ifStmt = defer \_ -> do
+   let
+      ifClause = do
+         c <- opTree'
+         b <- blockBody
+         pure (c × b)
+   reserved "if"
+   c <- ifClause
+   cs <- many (align $ reserved "elif" *> ifClause)
+   b <- align $ reserved "else" *> blockBody
+   pure $ If (nonEmpty (c : cs)) b
+
+-- Re-export opTree at top level so ifStmt can see it (opTree lives inside expr's
+-- where, but ifStmt is at top level and needs to parse a condition expression
+-- without the let/def alternatives that would leak indent state).
+opTree' :: Parser (Raw Expr)
+opTree' = defer \_ -> expr
 
 blockBody :: Parser (Raw Block)
 blockBody = defer \_ -> (Block <<< singleton) <$> block stmt
@@ -100,7 +119,7 @@ recDefs = many1 recDef
       pure $ p × Clause (ps × b)
 
 expr :: Parser (Raw Expr)
-expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
+expr = context "expr" $ matchAs <|> def <|> ternary <?> "expression"
    where
    ternary :: Parser (Raw Expr)
    ternary = defer \_ -> do
@@ -110,7 +129,7 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
          cond <- opTree
          reserved "else"
          e2 <- expr
-         pure $ IfElse (singleton (cond × returns e1)) (returns e2)
+         pure $ Ternary cond e1 e2
 
    matchAs :: Parser (Raw Expr)
    matchAs = do
@@ -133,29 +152,16 @@ expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
       funDef <|> valDef
       where
       funDef :: Parser (Raw Expr)
-      funDef = context "funDef" $ withPos do
+      funDef = context "funDef" $ withPos' do
          ds <- recDefs
          ss <- many1 (align stmt)
          pure $ LetRec ds (Block ss)
 
       valDef :: Parser (Raw Expr)
-      valDef = context "valDef" $ withPos do
+      valDef = context "valDef" $ withPos' do
          ds <- varDefs
          ss <- many1 (align stmt)
          pure $ Let ds (Block ss)
-
-   ifElse :: Parser (Raw Expr)
-   ifElse = do
-      reserved "if"
-      c <- clause
-      cs <- many (align $ reserved "elif" *> clause)
-      b <- align $ reserved "else" *> blockBody
-      pure $ IfElse (nonEmpty (c : cs)) b
-      where
-      clause = do
-         c <- opTree
-         b <- blockBody
-         pure (c × b)
 
    opTree :: Parser (Raw Expr)
    opTree = context "opTree" (buildExprParser opTable simpleChain) <* consume -- otherwise always `consume: false`

--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -89,7 +89,7 @@ ifStmt :: Parser (Raw Stmt)
 ifStmt = defer \_ -> do
    let
       ifClause = do
-         c <- opTree'
+         c <- expr
          b <- blockBody
          pure (c × b)
    reserved "if"
@@ -97,12 +97,6 @@ ifStmt = defer \_ -> do
    cs <- many (align $ reserved "elif" *> ifClause)
    b <- align $ reserved "else" *> blockBody
    pure $ If (nonEmpty (c : cs)) b
-
--- Re-export opTree at top level so ifStmt can see it (opTree lives inside expr's
--- where, but ifStmt is at top level and needs to parse a condition expression
--- without the let/def alternatives that would leak indent state).
-opTree' :: Parser (Raw Expr)
-opTree' = defer \_ -> expr
 
 blockBody :: Parser (Raw Block)
 blockBody = defer \_ -> (Block <<< singleton) <$> block stmt

--- a/fluid/src/Parse.purs
+++ b/fluid/src/Parse.purs
@@ -100,8 +100,18 @@ recDefs = many1 recDef
       pure $ p × Clause (ps × b)
 
 expr :: Parser (Raw Expr)
-expr = context "expr" $ matchAs <|> ifElse <|> def <|> opTree <?> "expression"
+expr = context "expr" $ matchAs <|> ifElse <|> def <|> ternary <?> "expression"
    where
+   ternary :: Parser (Raw Expr)
+   ternary = do
+      e1 <- opTree
+      option e1 $ try do
+         reserved "if"
+         cond <- opTree
+         reserved "else"
+         e2 <- expr
+         pure $ IfElse (singleton (cond × returns e1)) (returns e2)
+
    matchAs :: Parser (Raw Expr)
    matchAs = do
       reserved "match"

--- a/fluid/src/Parse/Parser.purs
+++ b/fluid/src/Parse/Parser.purs
@@ -3,6 +3,8 @@ module Parse.Parser where
 import Prelude hiding (between)
 
 import Control.Alt ((<|>))
+import Control.Monad.Error.Class (catchError, throwError)
+import Control.Monad.State.Class (get)
 import Control.Monad.State.Trans (put)
 import Control.Monad.Trans.Class (lift)
 import Data.Array (cons, elem)
@@ -72,6 +74,20 @@ block e = delim ':' *> sameOrIndented *> withPos e
 
 align :: forall a. Parser a -> Parser a
 align p = checkIndent *> p
+
+-- Like withPos, but restores the indent reference on failure too.
+-- Parsing.Indent's withPos leaves indent state mutated when its body throws,
+-- which leaks across `<|>` alternatives and breaks layout-sensitive parses.
+withPos' :: forall a. Parser a -> Parser a
+withPos' p = do
+   saved <- lift get
+   pos <- position
+   lift (put pos)
+   r <- catchError p \e -> do
+      lift (put saved)
+      throwError e
+   lift (put saved)
+   pure r
 
 identifier :: Parser Char -> Parser Char -> Parser String
 identifier start letter = lexeme $ do

--- a/fluid/src/Parse/Parser.purs
+++ b/fluid/src/Parse/Parser.purs
@@ -76,10 +76,8 @@ align :: forall a. Parser a -> Parser a
 align p = checkIndent *> p
 
 -- Like withPos, but restores the indent reference on failure too.
--- Parsing.Indent's withPos leaves indent state mutated when its body throws,
--- which leaks across `<|>` alternatives and breaks layout-sensitive parses.
-withPos' :: forall a. Parser a -> Parser a
-withPos' p = do
+withPosReset :: forall a. Parser a -> Parser a
+withPosReset p = do
    saved <- lift get
    pos <- position
    lift (put pos)

--- a/fluid/src/Pretty.purs
+++ b/fluid/src/Pretty.purs
@@ -72,7 +72,7 @@ instance Ann a => IsSimple (Expr a) where
    isSimple (Lambda _) = false
    isSimple (Let _ _) = false
    isSimple (LetRec _ _) = false
-   isSimple (IfElse _ _) = false
+   isSimple (Ternary _ _ _) = false
    isSimple (MatchAs _ _) = false
    isSimple _ = true
 
@@ -144,14 +144,8 @@ instance Ann a => Pretty (Expr a) where
    pretty (BinaryApp s op s') = expr $ operatorApp 0 (BinaryApp s op s')
    pretty (UnaryPrefixApp op s) = expr $ operatorApp 0 (UnaryPrefixApp op s)
    pretty (MatchAs s cs) = text "match" <+> pretty s <> block (pretty cs)
-   pretty (IfElse (NonEmptyList ((cond × Block (NonEmptyList (Return e1 :| Nil))) :| Nil)) (Block (NonEmptyList (Return e2 :| Nil))))
-      | isSimple e1 && isSimple e2 =
-           expr $ pretty e1 <+> text "if" <+> pretty cond <+> text "else" <+> pretty e2
-   pretty (IfElse (NonEmptyList (ss :| sss)) e) =
-      vsep (prettyClause "if" ss : (prettyClause "elif" <$> sss))
-         <++> text "else" <> block (pretty e)
-      where
-      prettyClause w (s × s') = text w <+> expr (pretty s) <> block (pretty s')
+   pretty (Ternary cond e1 e2) =
+      expr $ pretty e1 <+> text "if" <+> pretty cond <+> text "else" <+> pretty e2
 
    pretty (ListEmpty α) = highlightIf α (text "[]")
    pretty (ListNonEmpty α e rest) =
@@ -212,6 +206,11 @@ instance Ann a => Pretty (Block a) where
 
 instance Ann a => Pretty (Stmt a) where
    pretty (Return e) = pretty e
+   pretty (If (NonEmptyList (ss :| sss)) e) =
+      vsep (prettyClause "if" ss : (prettyClause "elif" <$> sss))
+         <++> text "else" <> block (pretty e)
+      where
+      prettyClause w (s × b) = text w <+> expr (pretty s) <> block (pretty b)
 
 instance Ann a => Pretty (Clause a) where
    pretty (Clause (ps × b)) = lambda (toList ps) b

--- a/fluid/src/Pretty.purs
+++ b/fluid/src/Pretty.purs
@@ -144,6 +144,9 @@ instance Ann a => Pretty (Expr a) where
    pretty (BinaryApp s op s') = expr $ operatorApp 0 (BinaryApp s op s')
    pretty (UnaryPrefixApp op s) = expr $ operatorApp 0 (UnaryPrefixApp op s)
    pretty (MatchAs s cs) = text "match" <+> pretty s <> block (pretty cs)
+   pretty (IfElse (NonEmptyList ((cond × Block (NonEmptyList (Return e1 :| Nil))) :| Nil)) (Block (NonEmptyList (Return e2 :| Nil))))
+      | isSimple e1 && isSimple e2 =
+           expr $ pretty e1 <+> text "if" <+> pretty cond <+> text "else" <+> pretty e2
    pretty (IfElse (NonEmptyList (ss :| sss)) e) =
       vsep (prettyClause "if" ss : (prettyClause "elif" <$> sss))
          <++> text "else" <> block (pretty e)

--- a/fluid/src/SExpr.purs
+++ b/fluid/src/SExpr.purs
@@ -50,7 +50,7 @@ data Expr a
    | BinaryApp (Expr a) Var (Expr a)
    | UnaryPrefixApp Var (Expr a)
    | MatchAs (Expr a) (NonEmptyList (Pattern × Block a))
-   | IfElse (NonEmptyList (Expr a × Block a)) (Block a)
+   | Ternary (Expr a) (Expr a) (Expr a)
    | Paragraph (Paragraph a)
    | ListEmpty a
    | ListNonEmpty a (Expr a) (ListRest a)
@@ -111,7 +111,10 @@ subpatts (Right (PListVar _)) = Nil
 subpatts (Right PListEnd) = Nil
 subpatts (Right (PListNext p o)) = Left p : Right o : Nil
 
-data Stmt a = Return (Expr a)
+data Stmt a
+   = Return (Expr a)
+   | If (NonEmptyList (Expr a × Block a)) (Block a)
+
 newtype Block a = Block (NonEmptyList (Stmt a))
 
 returns :: forall a. Expr a -> Block a
@@ -257,8 +260,10 @@ exprFwd (UnaryPrefixApp op s) =
    E.App (E.Op op) <$> desug s
 exprFwd (MatchAs s μ) =
    E.App <$> (E.Lambda top <$> desug (Clauses (Clause <$> first singleton <$> μ))) <*> desug s
-exprFwd (IfElse sss s) =
-   ifElseFwd (sss × s)
+exprFwd (Ternary cond e1 e2) =
+   E.App
+      <$> (E.Lambda top <$> (elimBool <$> (ContExpr <$> desug e1) <*> (ContExpr <$> desug e2)))
+      <*> desug cond
 exprFwd (Paragraph elems) =
    paragraphFwd elems
 exprFwd (ListEmpty α) =
@@ -284,8 +289,12 @@ exprFwd (DocExpr s s') = do
 
 type IfElseClauses a = NonEmptyList (Expr a × Block a) × Block a
 
+stmtFwd :: forall a m. BoundedLattice a => MonadError Error m => Stmt a -> m (E.Expr a)
+stmtFwd (Return e) = desug e
+stmtFwd (If sss s) = ifElseFwd (sss × s)
+
 blockFwd :: forall a m. BoundedLattice a => MonadError Error m => Block a -> m (E.Expr a)
-blockFwd (Block (NonEmptyList (Return e :| Nil))) = desug e
+blockFwd (Block (NonEmptyList (s :| Nil))) = stmtFwd s
 blockFwd _ = error "blockFwd: non-singleton block"
 
 ifElseFwd :: forall a m. BoundedLattice a => MonadError Error m => IfElseClauses a -> m (E.Expr a)

--- a/fluid/test/Specs/Misc.purs
+++ b/fluid/test/Specs/Misc.purs
@@ -50,4 +50,15 @@ misc_cases =
    , { file: "module/import_simple.fld", fwd_expect: "84" }
    , { file: "module/import_simple_unused.fld", fwd_expect: "84" }
    , { file: "module/import_modules.fld", fwd_expect: "84" }
+   , { file: "ternary/basic_true.fld", fwd_expect: "5" }
+   , { file: "ternary/basic_false.fld", fwd_expect: "6" }
+   , { file: "ternary/looser_than_plus.fld", fwd_expect: "7" }
+   , { file: "ternary/right_assoc_false.fld", fwd_expect: "3" }
+   , { file: "ternary/right_assoc_true.fld", fwd_expect: "1" }
+   , { file: "ternary/in_valdef_rhs.fld", fwd_expect: "3" }
+   , { file: "ternary/condition_parenthesised.fld", fwd_expect: "10" }
+   , { file: "ternary/listcomp_guard_unaffected.fld", fwd_expect: "2 :| 3 :| []" }
+   , { file: "ternary/inside_list_literal.fld", fwd_expect: "1 :| 4 :| []" }
+   , { file: "ternary/in_function_body.fld", fwd_expect: "3" }
+   , { file: "ternary/lambda_body.fld", fwd_expect: "0 :| 1 :| 2 :| 0 :| []" }
    ]

--- a/fluid/test/fluid/ternary/basic_false.fld
+++ b/fluid/test/fluid/ternary/basic_false.fld
@@ -1,0 +1,1 @@
+5 if False else 6

--- a/fluid/test/fluid/ternary/basic_true.fld
+++ b/fluid/test/fluid/ternary/basic_true.fld
@@ -1,0 +1,1 @@
+5 if True else 6

--- a/fluid/test/fluid/ternary/condition_parenthesised.fld
+++ b/fluid/test/fluid/ternary/condition_parenthesised.fld
@@ -1,0 +1,3 @@
+# Nested ternary in the condition requires parentheses (Python's or_test
+# rule). Inner ternary returns 2; 2 > 1 is True, so result is 10.
+10 if (2 if True else 3) > 1 else 20

--- a/fluid/test/fluid/ternary/condition_parenthesised.fld
+++ b/fluid/test/fluid/ternary/condition_parenthesised.fld
@@ -1,3 +1,2 @@
-# Nested ternary in the condition requires parentheses (Python's or_test
-# rule). Inner ternary returns 2; 2 > 1 is True, so result is 10.
+# Nested ternary in the condition requires parentheses (Python's or_test rule).
 10 if (2 if True else 3) > 1 else 20

--- a/fluid/test/fluid/ternary/in_function_body.fld
+++ b/fluid/test/fluid/ternary/in_function_body.fld
@@ -1,4 +1,4 @@
-# Ternary as the leaf expression of a function body (returned). Result: 3.
+# Ternary as the leaf expression of a function body (returned).
 def abs_(x):
   return x if x > 0 else 0 - x
 

--- a/fluid/test/fluid/ternary/in_function_body.fld
+++ b/fluid/test/fluid/ternary/in_function_body.fld
@@ -1,0 +1,5 @@
+# Ternary as the leaf expression of a function body (returned). Result: 3.
+def abs_(x):
+  return x if x > 0 else 0 - x
+
+abs_(-3)

--- a/fluid/test/fluid/ternary/in_function_body.fld
+++ b/fluid/test/fluid/ternary/in_function_body.fld
@@ -1,4 +1,3 @@
-# Ternary as the leaf expression of a function body (returned).
 def abs_(x):
   return x if x > 0 else 0 - x
 

--- a/fluid/test/fluid/ternary/in_valdef_rhs.fld
+++ b/fluid/test/fluid/ternary/in_valdef_rhs.fld
@@ -1,4 +1,2 @@
-# Common migration target: ternary as the RHS of a valDef where currently we'd
-# write 'def y: if cond: a else: b'.
 def y: 2 if True else 5
 y + 1

--- a/fluid/test/fluid/ternary/in_valdef_rhs.fld
+++ b/fluid/test/fluid/ternary/in_valdef_rhs.fld
@@ -1,0 +1,4 @@
+# Common migration target: ternary as the RHS of a valDef where currently we'd
+# write 'def y: if cond: a else: b'. Result: 3.
+def y: 2 if True else 5
+y + 1

--- a/fluid/test/fluid/ternary/in_valdef_rhs.fld
+++ b/fluid/test/fluid/ternary/in_valdef_rhs.fld
@@ -1,4 +1,4 @@
 # Common migration target: ternary as the RHS of a valDef where currently we'd
-# write 'def y: if cond: a else: b'. Result: 3.
+# write 'def y: if cond: a else: b'.
 def y: 2 if True else 5
 y + 1

--- a/fluid/test/fluid/ternary/inside_list_literal.fld
+++ b/fluid/test/fluid/ternary/inside_list_literal.fld
@@ -1,0 +1,2 @@
+# Ternary inside a list element. Result: 1 :| 4 :| [].
+[1 if True else 2, 3 if False else 4]

--- a/fluid/test/fluid/ternary/inside_list_literal.fld
+++ b/fluid/test/fluid/ternary/inside_list_literal.fld
@@ -1,2 +1,2 @@
-# Ternary inside a list element. Result: 1 :| 4 :| [].
+# Ternary inside a list element.
 [1 if True else 2, 3 if False else 4]

--- a/fluid/test/fluid/ternary/inside_list_literal.fld
+++ b/fluid/test/fluid/ternary/inside_list_literal.fld
@@ -1,2 +1,1 @@
-# Ternary inside a list element.
 [1 if True else 2, 3 if False else 4]

--- a/fluid/test/fluid/ternary/lambda_body.fld
+++ b/fluid/test/fluid/ternary/lambda_body.fld
@@ -1,2 +1,2 @@
-# Ternary in a lambda body. Result: 0 :| 1 :| 2 :| 0 :| [].
+# Ternary in a lambda body.
 map(lambda x: x if x > 0 else 0, [0, 1, 2, -5])

--- a/fluid/test/fluid/ternary/lambda_body.fld
+++ b/fluid/test/fluid/ternary/lambda_body.fld
@@ -1,2 +1,1 @@
-# Ternary in a lambda body.
 map(lambda x: x if x > 0 else 0, [0, 1, 2, -5])

--- a/fluid/test/fluid/ternary/lambda_body.fld
+++ b/fluid/test/fluid/ternary/lambda_body.fld
@@ -1,0 +1,2 @@
+# Ternary in a lambda body. Result: 0 :| 1 :| 2 :| 0 :| [].
+map(lambda x: x if x > 0 else 0, [0, 1, 2, -5])

--- a/fluid/test/fluid/ternary/listcomp_guard_unaffected.fld
+++ b/fluid/test/fluid/ternary/listcomp_guard_unaffected.fld
@@ -1,0 +1,3 @@
+# The 'if' in a list comprehension's qualifier chain must not be parsed as a
+# ternary. Result: 2 :| 3 :| [].
+[x for x in [1, 2, 3] if x > 1]

--- a/fluid/test/fluid/ternary/listcomp_guard_unaffected.fld
+++ b/fluid/test/fluid/ternary/listcomp_guard_unaffected.fld
@@ -1,3 +1,3 @@
 # The 'if' in a list comprehension's qualifier chain must not be parsed as a
-# ternary. Result: 2 :| 3 :| [].
+# ternary.
 [x for x in [1, 2, 3] if x > 1]

--- a/fluid/test/fluid/ternary/looser_than_plus.fld
+++ b/fluid/test/fluid/ternary/looser_than_plus.fld
@@ -1,2 +1,2 @@
-# Ternary is looser than +, so this parses as (1 + 2) if False else (3 + 4) = 7.
+# Ternary is looser than +, so this parses as (1 + 2) if False else (3 + 4).
 1 + 2 if False else 3 + 4

--- a/fluid/test/fluid/ternary/looser_than_plus.fld
+++ b/fluid/test/fluid/ternary/looser_than_plus.fld
@@ -1,0 +1,2 @@
+# Ternary is looser than +, so this parses as (1 + 2) if False else (3 + 4) = 7.
+1 + 2 if False else 3 + 4

--- a/fluid/test/fluid/ternary/right_assoc_false.fld
+++ b/fluid/test/fluid/ternary/right_assoc_false.fld
@@ -1,3 +1,3 @@
 # Right-associative on the else side, so this parses as
-# 1 if False else (2 if False else 3) = 3.
+# 1 if False else (2 if False else 3).
 1 if False else 2 if False else 3

--- a/fluid/test/fluid/ternary/right_assoc_false.fld
+++ b/fluid/test/fluid/ternary/right_assoc_false.fld
@@ -1,0 +1,3 @@
+# Right-associative on the else side, so this parses as
+# 1 if False else (2 if False else 3) = 3.
+1 if False else 2 if False else 3

--- a/fluid/test/fluid/ternary/right_assoc_true.fld
+++ b/fluid/test/fluid/ternary/right_assoc_true.fld
@@ -1,2 +1,1 @@
-# First branch taken short-circuits over nested ternary on else.
 1 if True else 2 if False else 3

--- a/fluid/test/fluid/ternary/right_assoc_true.fld
+++ b/fluid/test/fluid/ternary/right_assoc_true.fld
@@ -1,2 +1,2 @@
-# First branch taken: 1.
+# First branch taken short-circuits over nested ternary on else.
 1 if True else 2 if False else 3

--- a/fluid/test/fluid/ternary/right_assoc_true.fld
+++ b/fluid/test/fluid/ternary/right_assoc_true.fld
@@ -1,0 +1,2 @@
+# First branch taken: 1.
+1 if True else 2 if False else 3

--- a/website/article/static/fluid/scigen.fld
+++ b/website/article/static/fluid/scigen.fld
@@ -17,9 +17,7 @@ def ordinal(n):
         return error("n > 20 not supported")
 
 def rankLabel(word, n):
-  def prefix:
-    if n == 1: ""
-    else: ordinal(n) ++ "-"
+  def prefix: "" if n == 1 else ordinal(n) ++ "-"
   return prefix ++ word
 
 def trendWord(n1, n2, compareWord):


### PR DESCRIPTION
## Summary

Adds the Python-style ternary expression \`a if c else b\` (#1415), then uses it to retire block-form \`if/else\` from the expression layer.

**Parser (#1415)**
- New \`ternary\` parser at expression position: \`opTree ('if' opTree 'else' expr)?\`
- Looser than every operator (matches Python).
- Right-associative on the \`else\` side.
- Condition is \`opTree\` (Python's \`or_test\`) — nested ternary in the condition needs parens.
- Backwards-compatible: without \`if\`, ternary is just \`opTree\`.

**Surface AST split**
- New \`Ternary cond e1 e2\` in \`Expr\` — only ternary syntax produces this.
- New \`If clauses else_block\` in \`Stmt\` — block-form \`if/elif/else\` now parses only at statement position.
- Old \`IfElse\` in \`Expr\` removed.
- Matches Python's rule: block-form \`if/else\` is a statement, never an expression.

**Migration**
- The 3 remaining \`def x:\n  if X: a\n  else: b\` patterns (\`fluid/lib/graphics.fld\`, \`website/article/static/fluid/scigen.fld\`) rewritten to ternary. The hard-linked website libs propagate automatically.

**Pretty**
- Ternary always prints as \`e1 if cond else e2\`.
- \`If\` always prints as block form.
- The earlier \`isSimple\`-guarded workaround for one-clause IfElse is gone.

**Parser hygiene**
- Adds \`withPos'\` to \`Parse/Parser.purs\` — a \`withPos\` that restores indent state on failure too. Required because \`ifStmt\`'s condition parses via \`expr\`, and \`expr → def → withPos\` was leaking indent reference across \`<|>\` alternatives when \`recDefs\`/\`varDefs\` failed to match.

## Test plan

- [x] All 114 existing tests pass (103 prior + 11 new ternary cases)
- [x] 0 warnings, 0 errors in strict build
- [x] Ternary cases cover: basic branches, looser-than-+ precedence, right-associative else chains, valDef-RHS form, parenthesised condition, list-comp \`if\`-guard not eaten, ternary inside list literal / function body / lambda body

🤖 Generated with [Claude Code](https://claude.com/claude-code)